### PR TITLE
Removed defining shop ids.

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -188,6 +188,7 @@ local Raycast = function()
 end
 
 local GetJobGrade = function(jobConfig)
+	if (jobConfig == nil) then return nil end
 	local job = jobConfig[ESX.PlayerData.job.name] or jobConfig
 	if (job == nil) then return nil end
 	job = tonumber(job)
@@ -199,7 +200,7 @@ local Blips = {}
 local CreateLocationBlip = function(shopDetails, location)
 	local jobGrade = GetJobGrade(shopDetails.job)
 
-	if (shopDetails.blip and ESX.PlayerData.job.grade >= jobGrade) then
+	if (shopDetails.blip and (shopDetails.job == nil or (jobGrade ~= nil and ESX.PlayerData.job.grade >= jobGrade))) then
 		local blipId = #Blips
 		Blips[blipId] = AddBlipForCoord(location.x, location.y)
 		SetBlipSprite(Blips[blipId], shopDetails.blip.id)

--- a/client.lua
+++ b/client.lua
@@ -231,7 +231,7 @@ local CreateShopLocations = function()
 end
 
 local CreateLocationBlip = function(shopDetails, location)
-	if (shopDetails.blip and (not shopDetails.jobinfo or shopDetails.jobinfo.job == ESX.PlayerData.job.name)) then
+	if (shopDetails.blip and (not shopDetails or shopDetails.job == ESX.PlayerData.job.name)) then
 		local blipId = #Blips
 		Blips[blipId] = AddBlipForCoord(location.x, location.y)
 		SetBlipSprite(Blips[blipId], shopDetails.blip.id)
@@ -266,7 +266,7 @@ local Markers = function(tb, type, rgb, playerCoords, name)
 			if closestMarker == nil or currentMarker and distance < currentMarker[1] or closestMarker and distance < closestMarker[1] then
 				return {distance, k, type, name}
 			end
-		elseif not marker and distance < 8 then nearbyMarkers[id] = {x = v.x, y = v.y, z = v.z, r = rgb.x, g = rgb.y, b = rgb.z} elseif marker and distance > 8 then nearbyMarkers[id] = nil end
+		elseif not marker and distance < 8 then nearbyMarkers[id] = {x = v.x, y = v.y, z = v.z, r = rgb[1], g = rgb[2], b = rgb[3]} elseif marker and distance > 8 then nearbyMarkers[id] = nil end
 	end
 end
 

--- a/client.lua
+++ b/client.lua
@@ -238,11 +238,7 @@ local CreateShopLocations = function()
 				local heading = target.heading or 0.0
 				local distance = target.distance or 3.0
 				exports['qtarget']:AddBoxZone('shop-'..shopName, target.loc, length, width, {
-					name=id..'-'..shopName,
-					heading=heading,
-					debugPoly=false,
-					minZ=target.minZ,
-					maxZ=target.maxZ
+					name=id..'-'..shopName, heading=heading, debugPoly=false, minZ=target.minZ, maxZ=target.maxZ
 				}, {
 					options = {
 						{

--- a/client.lua
+++ b/client.lua
@@ -202,21 +202,14 @@ local CreateShopLocations = function()
 				local width = target.width or 0.5
 				local heading = target.heading or 0.0
 				local distance = target.distance or 3.0
-				exports['qtarget']:AddBoxZone(type..'-'..name, target.loc, length, width, {
-					name=id..'-'..name,
-					heading=heading,
-					debugPoly=false,
-					minZ=target.minZ,
-					maxZ=target.maxZ
-				}, {
-					options = {
+				exports['qtarget']:AddBoxZone('shop-'..shopName..'-'..id, target.loc, length, width, {
+					name=id..'-'..shopName, heading=heading, debugPoly=false, minZ=target.minZ, maxZ=target.maxZ
+				}, { options = {
 						{
 							icon = "fas fa-shopping-basket",
 							label = "Open " .. shopDetails.name,
 							job = shopDetails.job,
-							action = function(entity)
-								OpenInventory('shop', shopName)
-							end,
+							action = function(entity) OpenInventory('shop', shopName) end,
 						},
 					},
 					distance = distance

--- a/client.lua
+++ b/client.lua
@@ -194,13 +194,37 @@ local CreateShopLocations = function()
 	end
 	Blips = {}
 	for shopName, shopDetails in pairs(Shops) do
-		if (not Config.qtarget and #shopDetails.locations > 0) then
+		if (Config.qtarget == true) then
+			for id, target in pairs(shopDetails.targets) do
+				CreateLocationBlip(shopDetails, target.loc)
+
+				local length = target.length or 0.5
+				local width = target.width or 0.5
+				local heading = target.heading or 0.0
+				local distance = target.distance or 3.0
+				exports['qtarget']:AddBoxZone(type..'-'..name, target.loc, length, width, {
+					name=id..'-'..name,
+					heading=heading,
+					debugPoly=false,
+					minZ=target.minZ,
+					maxZ=target.maxZ
+				}, {
+					options = {
+						{
+							icon = "fas fa-shopping-basket",
+							label = "Open " .. shopDetails.name,
+							job = shopDetails.job,
+							action = function(entity)
+								OpenInventory('shop', shopName)
+							end,
+						},
+					},
+					distance = distance
+				})
+			end
+		else
 			for _, location in pairs(shopDetails.locations) do
 				CreateLocationBlip(shopDetails, location)
-			end
-		elseif (Config.qtarget and #shopDetails.targets > 0) then
-			for _, target in pairs(shopDetails.targets) do
-				CreateLocationBlip(shopDetails, target.loc)
 			end
 		end
 	end

--- a/data/shops.lua
+++ b/data/shops.lua
@@ -75,7 +75,7 @@ Data.Ammunation = {
 
 Data.PoliceArmoury = {
 	name = 'Police Armoury',
-	jobinfo = { job = { ['police'] = 1 } },
+	job = { ['police'] = 1 },
 	blip = { 
 		id = 110, colour = 84, scale = 0.6
 	}, inventory = {
@@ -89,13 +89,13 @@ Data.PoliceArmoury = {
 	}, locations = {
 		vector3(487.235, -997.108, 30.69)
 	}, targets = {
-		{ loc = vector3(487.235, -997.108, 30.69), length = 0.5, width = 3.0, heading = 60.0, distance = 6 }
+		{ loc = vector3(487.235, -997.108, 30.69), length = 0.5, width = 3.0, heading = 60.0, minZ = 29.0, maxZ = 31.0, distance = 6 }
 	}
 }
 
 Data.Medicine = {
 	name = 'Medicine Cabinet',
-	jobinfo = { job = 'ambulance' },
+	job = 'ambulance',
 	blip = {
 		id = 403, colour = 69, scale = 0.6
 	}, inventory = {


### PR DESCRIPTION
Correct me if i'm wrong, but there's no purpose of using shop ids now with the new system. It will just make opening shops more difficult when not automated.

Instead of having to supply OpenInventory('shop' {id = shopid, type = shoptype}) you can now just pass through OpenInventory('shop' { shoptype }) - or at least will be able to if you accept this commit.

I've defaulted the ID in the server side to 1, though I'm not sure if there's a point of even having a .id? - while it was null it still opened the shop as expected.