### PR TITLE
fix(css): long labels have now working ellipsis

### DIFF
--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -148,6 +148,7 @@ img {
     text-align: center;
     text-transform: uppercase;
     white-space: nowrap;
+    overflow: hidden;
     text-overflow: ellipsis;
     border-bottom-left-radius: $borderRadius;
     border-bottom-right-radius: $borderRadius;


### PR DESCRIPTION
`text-overflow: ellipsis;` doesn't work without setting overflow to hidden.