### PR TITLE
fix(shops): Remove durability bar on shop items

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -163,7 +163,7 @@ Utils.RegisterServerCallback('ox_inventory:swapItems', function(source, cb, data
 						toSlot.slot = data.toSlot
 						toSlot.weight = Inventory.SlotWeight(Items(toSlot.name), toSlot)
 						local newWeight = toInventory.weight + toSlot.weight
-						if newWeight <= toInventory.maxWeight then
+						if newWeight <= toInventory.maxWeight or toInventory.id == fromInventory.id then
 							fromSlot.count = fromSlot.count - data.count
 							fromSlot.weight = Inventory.SlotWeight(Items(fromSlot.name), fromSlot)
 							if fromInventory.id ~= toInventory.id then

--- a/web/src/components/inventory/InventorySlot.tsx
+++ b/web/src/components/inventory/InventorySlot.tsx
@@ -120,7 +120,7 @@ const InventorySlot: React.FC<SlotProps> = ({ inventory, item, setCurrentItem })
                 {item.count?.toLocaleString('en-us')}x
               </span>
             </div>
-            {item?.durability !== undefined && <WeightBar percent={item.durability} durability />}
+            {(inventory.type !== 'shop' && item?.durability !== undefined) && <WeightBar percent={item.durability} durability />}
             {inventory.type === 'shop' && item?.price && (
               <>
                 {item?.currency !== 'money' &&


### PR DESCRIPTION
Sometimes when you purchase an weapon and use it, it would show a durability bar on the item in the shop inventory.