### PR TITLE
feat(inventory): Add view inv admin command

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -421,7 +421,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(drops, inventory, w
 						local id = GetPlayerFromServerId(currentInventory.id)
 						local ped = GetPlayerPed(id)
 						local pedCoords = GetEntityCoords(ped)
-						if not id or #(playerCoords - pedCoords) > 1.8 or not (ESX.PlayerData.job.name == 'police' or CanOpenTarget(ped)) then
+						if not id or (#(playerCoords - pedCoords) > 1.8 or not (ESX.PlayerData.job.name == 'police' or CanOpenTarget(ped)) and ESX.PlayerData.group ~= 'admin') then
 							TriggerEvent('ox_inventory:closeInventory')
 							Notify({type = 'error', text = ox.locale('inventory_lost_access'), duration = 2500})
 						else
@@ -606,6 +606,7 @@ end)
 RegisterNetEvent('esx:playerLoaded', function(xPlayer)
 	ESX.PlayerData = xPlayer
 	ESX.PlayerLoaded = true
+	ESX.SetPlayerData('group', Utils.AwaitServerCallback('ox_inventory:getGroup'))
 end)
 
 RegisterNetEvent('esx:onPlayerLogout', function()

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -725,7 +725,14 @@ end, true, {help = 'Returns confiscated items to a player', validate = true, arg
 
 ESX.RegisterCommand('clearinv', 'admin', function(xPlayer, args, showError)
 	TriggerEvent('ox_inventory:clearPlayerInventory', args.playerId)
-end, true, {help = 'Returns confiscated items to a player', validate = true, arguments = {
+end, true, {help = 'Clear the inventory of a player', validate = true, arguments = {
+	{name = 'playerId', help = 'player id', type = 'player'},
+}})
+
+ESX.RegisterCommand('viewinv', 'admin', function(xPlayer, args, showError)
+	if args.playerId.source == xPlayer.source then return end
+	TriggerClientEvent('ox_inventory:openInventory', xPlayer.source, 'player', {id = args.playerId.source})
+end, true, {help = 'View the inventory of a player', validate = true, arguments = {
 	{name = 'playerId', help = 'player id', type = 'player'},
 }})
 

--- a/server.lua
+++ b/server.lua
@@ -356,3 +356,7 @@ Utils.RegisterServerCallback('ox_inventory:useItem', function(source, cb, item, 
 	end
 	cb(false)
 end)
+
+Utils.RegisterServerCallback('ox_inventory:getGroup', function(source, cb)
+	cb(ESX.GetPlayerFromId(source).getGroup())
+end)


### PR DESCRIPTION
Allows admins to view the inventory of a player by id, added a check if user is an admin or else the inventory gets closed when not nearby.

Issue reference: https://trello.com/c/9RCP0LOa/7-view-target-inventory

