### PR TITLE
Limit the quantity for an item (Optional)

### DIFF
--- a/data/items.lua
+++ b/data/items.lua
@@ -130,6 +130,7 @@ return {
 	['water'] = {
 		label = 'Water',
 		weight = 500,
+		limit = 15,
 		client = {
 			status = { thirst = 200000 },
 			anim = { dict = 'mp_player_intdrink', clip = 'loop_bottle' },

--- a/data/items.lua
+++ b/data/items.lua
@@ -29,6 +29,7 @@ return {
 		label = 'Test Burger',
 		weight = 220,
 		degrade = 60,
+		limit = 3,
 		client = {
 			status = { hunger = 200000 },
 			anim = { dict = 'mp_player_inteat@burger', clip = 'mp_player_int_eat_burger_fp' },
@@ -130,7 +131,6 @@ return {
 	['water'] = {
 		label = 'Water',
 		weight = 500,
-		limit = 15,
 		client = {
 			status = { thirst = 200000 },
 			anim = { dict = 'mp_player_intdrink', clip = 'loop_bottle' },

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -511,6 +511,7 @@ M.CanCarryItem = function(inv, item, count, metadata)
 		if type(inv) ~= 'table' then inv = Inventories[inv] end
 		local itemSlots, _, emptySlots = GetItemSlots(inv, item, metadata == nil and {} or type(metadata) == 'string' and {type=metadata} or metadata)
 		if #itemSlots > 0 or emptySlots > 0 then
+			if inv.type == 'player' and item.limit and (toCount + count) > item.limit then return false end
 			if item.weight == 0 then return true end
 			if count == nil then count = 1 end
 			local newWeight = inv.weight + (item.weight * count)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -425,7 +425,7 @@ end
 ---@param inv any
 ---@param item table|string
 ---@param metadata? table
-local GetItemSlots = function(inv, item, metadata)
+M.GetItemSlots = function(inv, item, metadata)
 	if type(inv) ~= 'table' then inv = Inventories[inv] end
 	local totalCount, slots, emptySlots = 0, {}, inv.slots
 	for k, v in pairs(inv.items) do
@@ -457,7 +457,7 @@ M.RemoveItem = function(inv, item, count, metadata, slot)
 		if metadata ~= nil then
 			metadata = type(metadata) == 'string' and {type=metadata} or metadata
 		end
-		local itemSlots, totalCount = GetItemSlots(inv, item, metadata)
+		local itemSlots, totalCount = M.GetItemSlots(inv, item, metadata)
 		if count > totalCount then count = totalCount end
 		local removed, total, slots = 0, count, {}
 		if slot and itemSlots[slot] then
@@ -509,9 +509,9 @@ M.CanCarryItem = function(inv, item, count, metadata)
 	if type(item) ~= 'table' then item = Items(item) end
 	if item then
 		if type(inv) ~= 'table' then inv = Inventories[inv] end
-		local itemSlots, toCount, emptySlots = GetItemSlots(inv, item, metadata == nil and {} or type(metadata) == 'string' and {type=metadata} or metadata)
+		local itemSlots, totalCount, emptySlots = M.GetItemSlots(inv, item, metadata == nil and {} or type(metadata) == 'string' and {type=metadata} or metadata)
 		if #itemSlots > 0 or emptySlots > 0 then
-			if inv.type == 'player' and item.limit and (toCount + count) > item.limit then return false end
+			if inv.type == 'player' and item.limit and (totalCount + count) > item.limit then return false end
 			if item.weight == 0 then return true end
 			if count == nil then count = 1 end
 			local newWeight = inv.weight + (item.weight * count)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -509,7 +509,7 @@ M.CanCarryItem = function(inv, item, count, metadata)
 	if type(item) ~= 'table' then item = Items(item) end
 	if item then
 		if type(inv) ~= 'table' then inv = Inventories[inv] end
-		local itemSlots, _, emptySlots = GetItemSlots(inv, item, metadata == nil and {} or type(metadata) == 'string' and {type=metadata} or metadata)
+		local itemSlots, toCount, emptySlots = GetItemSlots(inv, item, metadata == nil and {} or type(metadata) == 'string' and {type=metadata} or metadata)
 		if #itemSlots > 0 or emptySlots > 0 then
 			if inv.type == 'player' and item.limit and (toCount + count) > item.limit then return false end
 			if item.weight == 0 then return true end

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -124,6 +124,10 @@ ServerCallback.Register('buyItem', function(source, cb, data)
 			local toItem = toData and Items(toData.name)
 			local metadata, count = Items.Metadata(xPlayer, fromItem, fromData.metadata and table.clone(fromData.metadata) or {}, data.count)
 			local price = count * fromData.price
+				
+			if fromItem.limit and (Inventory.Search(xPlayer.source, 2, fromItem.name, fromItem.metadata) + data.count) > fromItem.limit then
+				return cb(false, nil, {type = 'error', text = { ox.locale('cannot_carry')}})
+			end
 
 			if toData == nil or (fromItem.name == toItem.name and fromItem.stack and table.matches(toData.metadata, metadata)) then
 				local canAfford = Inventory.GetItem(source, currency, false, true) >= price

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -125,7 +125,8 @@ ServerCallback.Register('buyItem', function(source, cb, data)
 			local metadata, count = Items.Metadata(xPlayer, fromItem, fromData.metadata and table.clone(fromData.metadata) or {}, data.count)
 			local price = count * fromData.price
 				
-			if fromItem.limit and (Inventory.Search(xPlayer.source, 2, fromItem.name, fromItem.metadata) + data.count) > fromItem.limit then
+			local _, totalCount, _ = Inventory.GetItemSlots(xPlayer.source, fromItem, fromItem.metadata)
+			if fromItem.limit and (totalCount + data.count) > fromItem.limit then
 				return cb(false, nil, {type = 'error', text = { ox.locale('cannot_carry')}})
 			end
 

--- a/server.lua
+++ b/server.lua
@@ -193,11 +193,17 @@ ServerCallback.Register('swapItems', function(source, cb, data)
 			local fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
 			local sameInventory = fromInventory.id == toInventory.id or false
 
-			if not sameInventory and toInventory.type == 'player' then
+			if not sameInventory and toInventory.type == 'player' or toInventory.type == 'otherplayer' then
 				local fromData = fromInventory.items[data.fromSlot]
 				local fromItem = Items(fromData.name)
-				if fromItem.limit and (Inventory.Search(source, 2, fromData.name, fromData.metadata) + data.count) > fromItem.limit then
-					return cb(false, nil, {type = 'error', text = { ox.locale('cannot_carry')}})
+				local _, totalCount, _ = Inventory.GetItemSlots(toInventory, fromItem, fromItem.metadata)
+				if fromItem.limit and (totalCount + data.count) > fromItem.limit then
+					if toInventory.type == 'player' then
+						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = { ox.locale('cannot_carry')}})
+					elseif toInventory.type == 'otherplayer' then
+						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = { ox.locale('cannot_carry_other')}})
+					end
+					return cb(false)
 				end
 			end
 

--- a/server.lua
+++ b/server.lua
@@ -193,6 +193,14 @@ ServerCallback.Register('swapItems', function(source, cb, data)
 			local fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
 			local sameInventory = fromInventory.id == toInventory.id or false
 
+			if not sameInventory and toInventory.type == 'player' then
+				local fromData = fromInventory.items[data.fromSlot]
+				local fromItem = Items(fromData.name)
+				if fromItem.limit and (Inventory.Search(source, 2, fromData.name, fromData.metadata) + data.count) > fromItem.limit then
+					return cb(false, nil, {type = 'error', text = { ox.locale('cannot_carry')}})
+				end
+			end
+
 			if fromInventory.type == 'policeevidence' and not sameInventory then
 				if not toInventory.job.name == 'police' then return cb(false) end
 				if Config.TakeFromEvidence > toInventory.job.grade then


### PR DESCRIPTION
I think that's a must have to be able to prevent a player to carry more than X quantity of an item, even if the weight capacity is ok.
It's probably not the best way to do it at all, I'm a complete beginner, but at least you get the idea.

For example, you don't want to see a player with 15 heist bags in his inventory.
Or if you want to physically attach a chicken to the hand of a player when he just catched one from the farm.


PS: This was tested in `shops`, `trunks`, `gloveboxes`, and `give` feature with 3 players on the server. No issue for us, except when you `/steal` someone, didnt found where to put the limit (because of time, I work f*ing slowly ^^)