### PR TITLE
Export inventory UseSlot function

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -248,6 +248,7 @@ local function UseSlot(slot)
 		end
 	end
 end
+exports('useSlot', UseSlot)
 
 local function CanOpenTarget(ped)
 	return IsPedFatallyInjured(ped)


### PR DESCRIPTION
This adds an export of the Inventory's `UseSlot` function.

**Use Case**

I was writing a script where I wanted to force equip a weapon with its components. I found no real way to do this without copying a bunch of logic from the `UseSlot` function into my own script, which did not make any sense really.

I have therefore exported and used the `UseSlot` function directly.

Up to you on whether you believe this is useful or not, but I found it useful for my own script, so hopefully others will as well.