### PR TITLE
fix(server): Use "evidence" as name for evidence

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -116,7 +116,7 @@ ServerCallback.Register('openInventory', function(source, cb, inv, data)
 
 		elseif inv == 'policeevidence' then
 			if left.player.job.name == ox.police then
-				data = ('police-%s'):format(data)
+				data = ('evidence-%s'):format(data)
 				right = Inventory(data)
 				if not right then
 					right = Inventory.Create(data, ox.locale('police_evidence'), inv, 100, 0, 100000, false)


### PR DESCRIPTION
`/clearevidence` command deletes inventories with `evidence` prefix, not `police`.

Maybe it's better to use `police`, because somebody can already have database entires with this prefix, but I chose `evidence` as it makes more sense for future references.
Swap it if you want.