### PR TITLE
feat: Allow multiple police jobs

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -248,7 +248,7 @@ local function useSlot(slot)
 					ClearPedSecondaryTask(playerPed)
 					if data.throwable then item.throwable = true end
 					if currentWeapon then currentWeapon = Utils.Disarm(currentWeapon) end
-					local sleep = (PlayerData.job.name == ox.police and (GetWeapontypeGroup(data.hash) == 416676503 or GetWeapontypeGroup(data.hash) == 690389602)) and 400 or 1200
+					local sleep = (ox.isPolice(PlayerData.job.name) and (GetWeapontypeGroup(data.hash) == 416676503 or GetWeapontypeGroup(data.hash) == 690389602)) and 400 or 1200
 					local coords = GetEntityCoords(playerPed, true)
 					Utils.PlayAnimAdvanced(sleep*2, sleep == 400 and 'reaction@intimidation@cop@unarmed' or 'reaction@intimidation@1h', 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, -1, 50, 0.1)
 					Wait(sleep)
@@ -370,7 +370,7 @@ end
 local function OpenNearbyInventory()
 	if CanOpenInventory() then
 		local closestPlayer = Utils.GetClosestPlayer()
-		if closestPlayer.x < 2 and (PlayerData.job.name == ox.police or CanOpenTarget(closestPlayer.z)) then
+		if closestPlayer.x < 2 and (ox.isPolice(PlayerData.job.name) or CanOpenTarget(closestPlayer.z)) then
 			Utils.PlayAnim(2000, 'mp_common', 'givetake1_a', 1.0, 1.0, -1, 50, 0.0, 0, 0, 0)
 			OpenInventory('player', GetPlayerServerId(closestPlayer.y))
 		end
@@ -743,7 +743,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 
 			Markers(drops, 'drop', vec3(150, 30, 30))
 			if not ox.qtarget then
-				if PlayerData.job.name == ox.police then Markers(Inventory.Evidence, 'policeevidence', vec(30, 30, 150)) end
+				if ox.isPolice(PlayerData.job.name) then Markers(Inventory.Evidence, 'policeevidence', vec(30, 30, 150)) end
 				Markers(Inventory.Stashes, 'stash', vec3(30, 30, 150))
 				for k, v in pairs(Shops) do
 					if not v.jobs or (v.jobs[PlayerData.job.name] and PlayerData.job.grade >= v.jobs[PlayerData.job.name]) then
@@ -768,7 +768,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 						local ped = GetPlayerPed(id)
 						local pedCoords = GetEntityCoords(ped)
 
-						if not id or #(playerCoords - pedCoords) > 1.8 or not (PlayerData.job.name == ox.police or CanOpenTarget(ped)) then
+						if not id or #(playerCoords - pedCoords) > 1.8 or not (ox.isPolice(PlayerData.job.name) or CanOpenTarget(ped)) then
 							TriggerEvent('ox_inventory:closeInventory')
 							Utils.Notify({type = 'error', text = ox.locale('inventory_lost_access'), duration = 2500})
 						else

--- a/config.lua
+++ b/config.lua
@@ -101,7 +101,7 @@ ox = {
 	-- Default max weight of player inventory
 	playerweight = ox.playerweight or 30000,
 
-	-- Name of your police job
+	-- Name of your police job/s (string or table with grades)
 	police = ox.police or 'police',
 
 	-- Translations

--- a/data/shops.lua
+++ b/data/shops.lua
@@ -106,7 +106,7 @@ return {
 
 	PoliceArmoury = {
 		name = 'Police Armoury',
-		jobs = { [ox.police] = 0 },
+		jobs = ox.police,
 		blip = {
 			id = 110, colour = 84, scale = 0.8
 		}, inventory = {

--- a/data/stashes.lua
+++ b/data/stashes.lua
@@ -15,7 +15,7 @@ return {
 		owner = true,
 		slots = 70,
 		weight = 70000,
-		jobs = {[ox.police] = 0}
+		jobs = ox.police
 	},
 
 	{

--- a/modules/init.lua
+++ b/modules/init.lua
@@ -37,6 +37,11 @@ do
 	end
 end
 
+-- Checks if the passed job is allowed to use police-only features
+function ox.isPolice(job)
+	return ox.police == job or ox.police?[job] ~= nil
+end
+
 -- Disable qtarget compatibility if it isn't running
 if ox.qtarget and GetResourceState('qtarget') ~= 'started' then
 	ox.qtarget = false

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -962,7 +962,7 @@ end, {'target:number', 'item:string', 'count:number', 'metatype:?string'})
 
 import.commands(false, 'clearevidence', function(source, args)
 	local inventory = Inventories[source]
-	if inventory.player.job.name == ox.police and inventory.player.job.grade_name == 'boss' then
+	if ox.isPolice(inventory.player.job.name) and inventory.player.job.grade_name == 'boss' then
 		MySQL.query('DELETE FROM ox_inventory WHERE name = ?', {('evidence-%s'):format(args.evidence)})
 	end
 end, {'evidence:number'})
@@ -1036,7 +1036,7 @@ Inventory.CustomStash = table.create(0, 0)
 --- true: each player has a unique stash, but can request other player's stashes
 --- nil: always shared
 ---
---- Jobs: { [ox.police] = 0 }
+--- Jobs: { ['police'] = 0 }
 --- ```
 local function RegisterStash(id, label, slots, maxWeight, owner, jobs)
 	if not Inventory.CustomStash[id] then

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -69,7 +69,7 @@ function Utils.Disarm(currentWeapon, newSlot)
 
 		if not newSlot then
 			ClearPedSecondaryTask(PlayerData.ped)
-			local sleep = (PlayerData.job.name == ox.police and (GetWeapontypeGroup(currentWeapon.hash) == 416676503 or GetWeapontypeGroup(currentWeapon.hash) == 690389602)) and 450 or 1400
+			local sleep = (ox.isPolice(PlayerData.job.name) and (GetWeapontypeGroup(currentWeapon.hash) == 416676503 or GetWeapontypeGroup(currentWeapon.hash) == 690389602)) and 450 or 1400
 			local coords = GetEntityCoords(PlayerData.ped, true)
 			Utils.PlayAnimAdvanced(sleep, (sleep == 450 and 'reaction@intimidation@cop@unarmed' or 'reaction@intimidation@1h'), 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(PlayerData.ped), 8.0, 3.0, -1, 50, 0)
 			Wait(sleep)

--- a/server.lua
+++ b/server.lua
@@ -113,7 +113,7 @@ ServerCallback.Register('openInventory', function(source, inv, data)
 			end
 
 		elseif inv == 'policeevidence' then
-			if left.player.job.name == ox.police then
+			if ox.isPolice(left.player.job.name) then
 				data = ('evidence-%s'):format(data)
 				right = Inventory(data)
 				if not right then
@@ -227,7 +227,7 @@ ServerCallback.Register('swapItems', function(source, data)
 			end
 
 			if fromInventory.type == 'policeevidence' and not sameInventory then
-				if not toInventory.player.job.name == ox.police then return end
+				if not ox.isPolice(toInventory.player.job.name) then return end
 				if ox.evidencegrade > toInventory.player.job.grade then
 					TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = ox.locale('evidence_cannot_take')})
 					return


### PR DESCRIPTION
You can set up multiple jobs with individual grades. Uses same formats as qtarget:
```lua
police = 'police'
-- or
police = {
  police = 0,
  sheriff = 2
}
```