### PR TITLE
fix(exports): Use ox.resource resource name variable instead of static ox_inventory in export calls

### DIFF
--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -15,7 +15,7 @@ if ox.qtarget then
 			SetNetworkIdCanMigrate(netId, true)
 		end
 
-		exports.ox_inventory:openInventory('dumpster', 'dumpster'..netId)
+		exports[ox.resource]:openInventory('dumpster', 'dumpster'..netId)
 	end
 
 	exports.qtarget:AddTargetModel(Inventory.Dumpsters, {
@@ -69,7 +69,7 @@ end
 exports('Search', Inventory.Search)
 
 local function OpenEvidence()
-	exports.ox_inventory:openInventory('policeevidence')
+	exports[ox.resource]:openInventory('policeevidence')
 end
 
 Inventory.Evidence = setmetatable(data('evidence'), {
@@ -103,7 +103,7 @@ Inventory.Evidence = setmetatable(data('evidence'), {
 })
 
 local function OpenStash(data)
-	exports.ox_inventory:openInventory('stash', data)
+	exports[ox.resource]:openInventory('stash', data)
 end
 
 Inventory.Stashes = setmetatable(data('stashes'), {

--- a/modules/player/server.lua
+++ b/modules/player/server.lua
@@ -21,10 +21,10 @@ if ox.esx then
         local player = ox.GetPlayerFromId(source)
 
         if player and player.inventory then
-            exports.ox_inventory:setPlayerInventory(player, player.inventory)
+            exports[ox.resource]:setPlayerInventory(player, player.inventory)
         else
             MySQL.scalar('SELECT inventory FROM users WHERE identifier = ?', { player.identifier }, function(result)
-                exports.ox_inventory:setPlayerInventory(player, result and json.decode(result))
+                exports[ox.resource]:setPlayerInventory(player, result and json.decode(result))
             end)
         end
     end)

--- a/modules/shops/client.lua
+++ b/modules/shops/client.lua
@@ -13,7 +13,7 @@ local function CreateLocationBlip(blipId, name, blip, location)
 end
 
 local function OpenShop(data)
-	exports.ox_inventory:openInventory('shop', data)
+	exports[ox.resource]:openInventory('shop', data)
 end
 
 client.shops = setmetatable(data('shops'), {
@@ -35,7 +35,7 @@ client.shops = setmetatable(data('shops'), {
 									icon = 'fas fa-shopping-basket',
 									label = ox.locale('open_shop', shop.name),
 									action = function()
-										exports.ox_inventory:openInventory('shop', {type=type})
+										exports[ox.resource]:openInventory('shop', {type=type})
 									end
 								},
 							},


### PR DESCRIPTION
Only use ox.resource (defined in config, default GetCurrentResourceName()) for appropriate export calls instead of static "ox_inventory". 

If allowing to be able to seamlessly rename the resource is intended, more hard references will need to be replaced (not just exports). If this is the case I am happy to ammend this PR and replace anything necessary to allow for such behaviour. If not this will atleast create consistency with how export calls are used in the item module.

Replacement for #456 which accidentally contained german translation.