### PR TITLE
Better notification when trying to carry too much

### DIFF
--- a/data/locales/cs.lua
+++ b/data/locales/cs.lua
@@ -50,6 +50,8 @@ return {
 	['cannot_perform'] = "Tuto akci nelze provést",
 	['cannot_carry'] = "Tolik toho neunesete",
 	['cannot_carry_other'] = "Druhý inventář toho tolik neunese",
+	['cannot_carry_limit'] = "You only can carry %s %s maximum",
+	['cannot_carry_limit_other'] = "Target only can carry %s %s maximum",
 	['items_confiscated'] = "Vaše předměty byly zabaveny",
 	['items_returned'] = "Vaše předměty vám byly vráceny",
 	['item_unauthorised'] = "Nemáte pravomoce k zakoupení tohoto předmětu",

--- a/data/locales/da.lua
+++ b/data/locales/da.lua
@@ -50,6 +50,8 @@ return {
 	['cannot_perform'] = "Du kan ikke udføre denne handling",
 	['cannot_carry'] = "Du kan ikke bære så meget",
 	['cannot_carry_other'] = "Inventaret du prøver at lægge i kan ikke indeholde så meget",
+	['cannot_carry_limit'] = "You only can carry %s %s maximum",
+	['cannot_carry_limit_other'] = "Target only can carry %s %s maximum",
 	['items_confiscated'] = "Dine ting er blevet konfiskeret",
 	['items_returned'] = "Dine ting er blevet returneret",
 	['item_unauthorised'] = "Du har ikke tilladelse til at købe denne ting",

--- a/data/locales/de.lua
+++ b/data/locales/de.lua
@@ -50,6 +50,8 @@ return {
 	['cannot_perform'] = "Du kannst diese Aktion nicht ausführen",
 	['cannot_carry'] = "Du kannst nicht so viel tragen",
 	['cannot_carry_other'] = "Das Inventar hat nicht genügend Platz",
+	['cannot_carry_limit'] = "You only can carry %s %s maximum",
+	['cannot_carry_limit_other'] = "Target only can carry %s %s maximum",
 	['items_confiscated'] = "Deine Gegenstände wurden konfisziert",
 	['items_returned'] = "Deine Gegenstände wurden dir zurückgegeben",
 	['item_unauthorised'] = "Du bist nicht autorisiert diesen Gegenstand zu kaufen",

--- a/data/locales/en.lua
+++ b/data/locales/en.lua
@@ -50,6 +50,8 @@ return {
 	['cannot_perform'] = "You can not perform this action",
 	['cannot_carry'] = "You can not carry that much",
 	['cannot_carry_other'] = "Target inventory can not hold that much",
+	['cannot_carry_limit'] = "You only can carry %s %s maximum",
+	['cannot_carry_limit_other'] = "Target only can carry %s %s maximum",
 	['items_confiscated'] = "Your items have been confiscated",
 	['items_returned'] = "Your items have been returned",
 	['item_unauthorised'] = "You are not authorised to purchase this item",

--- a/data/locales/es.lua
+++ b/data/locales/es.lua
@@ -34,6 +34,8 @@ return {
 	['cannot_perform'] = "No puedes hacer eso o no lo estás haciendo bien",
 	['cannot_carry'] = "No puedes cargar tanto",
 	['cannot_carry_other'] = "No cabe en ese inventario",
+	['cannot_carry_limit'] = "You only can carry %s %s maximum",
+	['cannot_carry_limit_other'] = "Target only can carry %s %s maximum",
 	['items_confiscated'] = "Tus items han sido confiscadas",
 	['items_returned'] = "Tus items te han sido devueltos",
 	['item_unauthorised'] = "No estás autorizado para comprar este item",

--- a/data/locales/fr.lua
+++ b/data/locales/fr.lua
@@ -50,6 +50,8 @@ return {
 	['cannot_perform'] = "Vous ne pouvez pas faire cette action",
 	['cannot_carry'] = "Vous ne pouvez pas en porter autant",
 	['cannot_carry_other'] = "L’autre inventaire ne peut pas en porter autant",
+	['cannot_carry_limit'] = "Vous ne pouvez porter que %s %s maximum",
+	['cannot_carry_limit_other'] = "La personne ne peux porter que %s %s maximum",
 	['items_confiscated'] = "Vos objets ont été confisqués",
 	['items_returned'] = "Vos objets ont été retournés",
 	['item_unauthorised'] = "Vous n’êtes pas autorisé à acheter cet article",

--- a/data/locales/it.lua
+++ b/data/locales/it.lua
@@ -50,6 +50,8 @@ return {
 	['cannot_perform'] = "Non puoi eseguire questa azione",
 	['cannot_carry'] = "Non puoi portarne così tanti",
 	['cannot_carry_other'] = "L'altro inventario non può portarne così tanti",
+	['cannot_carry_limit'] = "You only can carry %s %s maximum",
+	['cannot_carry_limit_other'] = "Target only can carry %s %s maximum",
 	['items_confiscated'] = "I tuoi oggetti sono stati confiscati",
 	['items_returned'] = "I tuoi oggetti sono stati restituiti",
 	['item_unauthorised'] = "Non sei autorizzato a comprare questo oggetto",

--- a/data/locales/nl.lua
+++ b/data/locales/nl.lua
@@ -50,6 +50,8 @@ return {
 	['cannot_perform'] = "Je kan deze actie niet uitvoeren",
 	['cannot_carry'] = "Je kan niet zoveel dragen",
 	['cannot_carry_other'] = "Doel inventaris kan niet zoveel dragen",
+	['cannot_carry_limit'] = "You only can carry %s %s maximum",
+	['cannot_carry_limit_other'] = "Target only can carry %s %s maximum",
 	['items_confiscated'] = "Je items zijn in beslag genomen",
 	['items_returned'] = "Je items zijn teruggegeven",
 	['item_unauthorised'] = "Je bent niet geautoriseerd om dit item te kopen",

--- a/data/locales/pt-br.lua
+++ b/data/locales/pt-br.lua
@@ -50,6 +50,8 @@ return {
 	['cannot_perform'] = "Você não pode realizar esta ação",
 	['cannot_carry'] = "Você não pode carregar muito",
 	['cannot_carry_other'] = "O inventário de destino não pode conter tanto",
+	['cannot_carry_limit'] = "You only can carry %s %s maximum",
+	['cannot_carry_limit_other'] = "Target only can carry %s %s maximum",
 	['items_confiscated'] = "Seus itens foram confiscados",
 	['items_returned'] = "Seus itens foram devolvidos",
 	['item_unauthorised'] = "Você não está autorizado a comprar este item",

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -601,13 +601,20 @@ function Inventory.CanCarryItem(inv, item, count, metadata)
 		local itemSlots, totalCount, emptySlots = Inventory.GetItemSlots(inv, item, metadata == nil and {} or type(metadata) == 'string' and {type=metadata} or metadata)
 
 		if next(itemSlots) or emptySlots > 0 then
-			if inv.type == 'player' and item.limit and (totalCount + count) > item.limit then return false end
+			if inv.type == 'player' and item.limit and (totalCount + count) > item.limit then
+				TriggerClientEvent('ox_inventory:notify', playerId, {type = 'error', text = shared.locale('cannot_carry_limit', item.limit, item.label)})
+				return false
+			end
 			if item.weight == 0 then return true end
 			if count == nil then count = 1 end
 			local newWeight = inv.weight + (item.weight * count)
-			return newWeight <= inv.maxWeight
+			if newWeight >= inv.maxWeight then
+				TriggerClientEvent('ox_inventory:notify', playerId, {type = 'error', text = shared.locale('cannot_carry')})
+				return false
+			else
+				return true
+			end
 		end
-
 	end
 end
 exports('CanCarryItem', Inventory.CanCarryItem)

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -138,7 +138,7 @@ ServerCallback.Register('buyItem', function(source, data)
 
 			local _, totalCount, _ = Inventory.GetItemSlots(playerInv, fromItem, fromItem.metadata)
 			if fromItem.limit and (totalCount + data.count) > fromItem.limit then
-				return false, false, {type = 'error', text = { shared.locale('cannot_carry')}}
+				return false, false, {type = 'error', text = shared.locale('cannot_carry_limit', fromItem.limit, fromItem.label)}
 			end
 
 			if toData == nil or (fromItem.name == toItem.name and fromItem.stack and table.matches(toData.metadata, metadata)) then
@@ -146,7 +146,7 @@ ServerCallback.Register('buyItem', function(source, data)
 				if canAfford then
 					local newWeight = playerInv.weight + (fromItem.weight + (metadata?.weight or 0)) * count
 					if newWeight > playerInv.maxWeight then
-						return false, false, {type = 'error', text = { shared.locale('cannot_carry')}}
+						return false, false, {type = 'error', text = shared.locale('cannot_carry')}
 					else
 						Inventory.SetSlot(playerInv, fromItem, count, metadata, data.toSlot)
 						if fromData.count then shop.items[data.fromSlot].count = fromData.count - count end

--- a/server.lua
+++ b/server.lua
@@ -211,9 +211,9 @@ ServerCallback.Register('swapItems', function(source, data)
 				local _, totalCount, _ = Inventory.GetItemSlots(toInventory, fromItem, fromItem.metadata)
 				if fromItem.limit and (totalCount + data.count) > fromItem.limit then
 					if toInventory.type == 'player' then
-						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = { shared.locale('cannot_carry')}})
+						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = shared.locale('cannot_carry_limit', fromItem.limit, fromItem.label)})
 					elseif toInventory.type == 'otherplayer' then
-						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = { shared.locale('cannot_carry_other')}})
+						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = shared.locale('cannot_carry_limit_other', fromItem.limit, fromItem.label)})
 					end
 					return
 				end


### PR DESCRIPTION
I made those changes on my server and this is very easier for player to understand what is wrong when trying to swap, buy, give or rob items.

This is also probably better for people because they won't have to handle the notification themself when using `Inventory.CanCarryItem`.

I added locales for each languages but only french is translated.

![image](https://user-images.githubusercontent.com/47056777/150061680-4ddf0234-6564-47ba-b2bc-835426c9d1c4.png)
