### PR TITLE
feat(client): Allow individual target icons and labels

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -164,7 +164,7 @@ local function useItem(data, cb)
 				p = promise.new()
 				Interface.Progress({
 					duration = data.usetime,
-					label = shared.locale('using', result.label),
+					label = data.label or shared.locale('using', result.label),
 					useWhileDead = data.useWhileDead or false,
 					canCancel = data.cancel or false,
 					disable = data.disable,

--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -121,7 +121,7 @@ Inventory.Stashes = setmetatable(data('stashes'), {
 				}, {
 					options = {
 						{
-							icon = 'fas fa-warehouse',
+							icon = stash.target.icon or 'fas fa-warehouse',
 							label = stash.target.label or 'Open Stash',
 							job = stash.jobs,
 							action = function()

--- a/modules/shops/client.lua
+++ b/modules/shops/client.lua
@@ -33,7 +33,7 @@ client.shops = setmetatable(data('shops'), {
 							options = {
 								{
 									icon = 'fas fa-shopping-basket',
-									label = shared.locale('open_shop', shop.name),
+									label = shop.label or shared.locale('open_shop', shop.name),
 									action = function()
 										exports.ox_inventory:openInventory('shop', {type=type})
 									end
@@ -57,7 +57,7 @@ client.shops = setmetatable(data('shops'), {
 								options = {
 									{
 										icon = 'fas fa-shopping-basket',
-										label = shared.locale('open_shop', shop.name),
+										label = shop.label or shared.locale('open_shop', shop.name),
 										job = shop.jobs,
 										action = function()
 											OpenShop({id=id, type=type})


### PR DESCRIPTION
Option to have individually different:
- icons for stashes
- labels for shops
- labels for item progressbar