### PR TITLE
Weapons

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -248,8 +248,13 @@ local function useSlot(slot)
 					if currentWeapon then currentWeapon = Utils.Disarm(currentWeapon) end
 					local sleep = (client.isPolice() and (GetWeapontypeGroup(data.hash) == 416676503 or GetWeapontypeGroup(data.hash) == 690389602)) and 400 or 1200
 					local coords = GetEntityCoords(playerPed, true)
-					Utils.PlayAnimAdvanced(sleep*2, sleep == 400 and 'reaction@intimidation@cop@unarmed' or 'reaction@intimidation@1h', 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, -1, 50, 0.1)
-					Wait(sleep)
+					if item.name == 'WEAPON_SWITCHBLADE' then
+						Utils.PlayAnimAdvanced(sleep*2, 'anim@melee@switchblade@holster', 'unholster', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, -1, 48, 0.1)
+						Wait(100)
+					else
+						Utils.PlayAnimAdvanced(sleep*2, sleep == 400 and 'reaction@intimidation@cop@unarmed' or 'reaction@intimidation@1h', 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, -1, 50, 0.1)
+						Wait(sleep)
+					end
 					SetPedAmmo(playerPed, data.hash, 0)
 					GiveWeaponToPed(playerPed, data.hash, 0, false, true)
 

--- a/client.lua
+++ b/client.lua
@@ -284,7 +284,7 @@ local function useSlot(slot)
 					Wait(0)
 					RefillAmmoInstantly(playerPed)
 
-					if data.name == 'WEAPON_PETROLCAN' or data.name == 'WEAPON_FIREEXTINGUISHER' then
+					if data.name == 'WEAPON_PETROLCAN' or data.name == 'WEAPON_HAZARDCAN' or data.name == 'WEAPON_FIREEXTINGUISHER' then
 						item.metadata.ammo = item.metadata.durability
 						SetPedInfiniteAmmo(playerPed, true, data.hash)
 					end
@@ -934,7 +934,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 					if IsPedShooting(playerPed) then
 						local currentAmmo
 
-						if currentWeapon.name == 'WEAPON_PETROLCAN' or currentWeapon.name == 'WEAPON_FIREEXTINGUISHER' then
+						if currentWeapon.name == 'WEAPON_PETROLCAN' or currentWeapon.name == 'WEAPON_HAZARDCAN' or currentWeapon.name == 'WEAPON_FIREEXTINGUISHER' then
 							currentAmmo = currentWeapon.metadata.ammo - 0.05
 
 							if currentAmmo <= 0 then

--- a/client.lua
+++ b/client.lua
@@ -349,6 +349,8 @@ local function useSlot(slot)
 					end
 				end
 				Utils.Notify({type = 'error', text = shared.locale('component_invalid', data.label) })
+			elseif data.allowArmed then
+				useItem(data)
 			end
 		else
 			useItem(data)

--- a/client.lua
+++ b/client.lua
@@ -307,7 +307,6 @@ local function useSlot(slot)
 
 						if data then
 							if data.name == currentWeapon.ammo then
-								DisableControlActions:Add(22)
 								local missingAmmo = 0
 								local newAmmo = 0
 								missingAmmo = maxAmmo - currentAmmo
@@ -317,8 +316,6 @@ local function useSlot(slot)
 								MakePedReload(playerPed)
 								currentWeapon.metadata.ammo = newAmmo
 								TriggerServerEvent('ox_inventory:updateWeapon', 'load', currentWeapon.metadata.ammo)
-								Wait(1500)
-								DisableControlActions:Remove(22)
 							end
 						end
 					end)

--- a/data/items.lua
+++ b/data/items.lua
@@ -155,4 +155,12 @@ return {
 			notification = 'You drank some refreshing water'
 		}
 	},
+	
+	['radio'] = {
+		label = 'Radio',
+		weight = 1000,
+		stack = false,
+		consume = 0,
+		allowArmed = true
+	},
 }

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -71,8 +71,13 @@ function Utils.Disarm(currentWeapon, newSlot)
 			ClearPedSecondaryTask(PlayerData.ped)
 			local sleep = (client.isPolice() and (GetWeapontypeGroup(currentWeapon.hash) == 416676503 or GetWeapontypeGroup(currentWeapon.hash) == 690389602)) and 450 or 1400
 			local coords = GetEntityCoords(PlayerData.ped, true)
-			Utils.PlayAnimAdvanced(sleep, (sleep == 450 and 'reaction@intimidation@cop@unarmed' or 'reaction@intimidation@1h'), 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(PlayerData.ped), 8.0, 3.0, -1, 50, 0)
-			Wait(sleep)
+			if currentWeapon.name == 'WEAPON_SWITCHBLADE' then
+				Utils.PlayAnimAdvanced(sleep, 'anim@melee@switchblade@holster', 'holster', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(PlayerData.ped), 8.0, 3.0, -1, 48, 0)
+				Wait(600)
+			else
+				Utils.PlayAnimAdvanced(sleep, (sleep == 450 and 'reaction@intimidation@cop@unarmed' or 'reaction@intimidation@1h'), 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(PlayerData.ped), 8.0, 3.0, -1, 50, 0)
+				Wait(sleep)
+			end
 			Utils.ItemNotify({currentWeapon.label, currentWeapon.name, shared.locale('holstered')})
 		end
 


### PR DESCRIPTION
A few notes about the commits:

1. The switchblade animation is missing its classic sound (can be achieved with animation names `w_holster` and `w_unholster`, I couldn't do a mix of the two without glitching something, you're surely better than me and could try improve it.
2. I removed the disabled roll key during reload because was causing this weird behaviour where the ped is losing aim focus after reloading: https://streamable.com/pyk9dp
3. I could've reduced the wait time < 800 and it would have fixed the issue, however with that little wait time, you could roll anyway so I deleted it entirely. Also, the roll was disabled on manual reload only and not on automatic one.