### PR TITLE
feat(Logs) Robbery logged with OpenPlayerInventory item swaps

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -199,6 +199,7 @@ ServerCallback.Register('swapItems', function(source, data)
 			local sameInventory = fromInventory.id == toInventory.id or false
 			local container = (not sameInventory and playerInventory.containerSlot) and (fromInventory.type == 'container' and fromInventory or toInventory)
 			local containerItem = container and playerInventory.items[playerInventory.containerSlot]
+			local robbery = nil
 
 			if not sameInventory and toInventory.type == 'player' or toInventory.type == 'otherplayer' then
 				local fromData = fromInventory.items[data.fromSlot]
@@ -215,6 +216,20 @@ ServerCallback.Register('swapItems', function(source, data)
 						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = shared.locale('cannot_carry_limit_other', fromItem.limit, fromItem.label)})
 					end
 					return
+				end
+
+				if toInventory.type == 'player' and fromInventory.type == 'otherplayer' then
+					if shared.isPolice(playerInventory.player.job.name) == false then
+						robbery = '**ITEM ROBBERY**\n'
+					else
+						robbery = '**ITEM CONFISCATION BY POLICE** ('..playerInventory.player.job.name..')\n'
+					end
+				elseif toInventory.type == 'otherplayer' and fromInventory.type == 'player' then
+					if shared.isPolice(playerInventory.player.job.name) == false then
+						robbery = '**ITEM PLANTED BY CIVILIAN**\n'
+					else
+						robbery = '**ITEM PLANTED BY POLICE** ('..playerInventory.player.job.name..')\n'
+					end
 				end
 			end
 
@@ -256,7 +271,7 @@ ServerCallback.Register('swapItems', function(source, data)
 
 								Log(('%sx %s transferred from %s to %s for %sx %s'):format(fromData.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id, toData.count, toData.name),
 									playerInventory.owner,
-									'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
+									robbery or 'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
 								)
 
 							else return end
@@ -280,7 +295,7 @@ ServerCallback.Register('swapItems', function(source, data)
 
 								Log(('%sx %s transferred from %s to %s'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id),
 									playerInventory.owner,
-									'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
+									robbery or 'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
 								)
 
 							end
@@ -308,7 +323,7 @@ ServerCallback.Register('swapItems', function(source, data)
 
 								Log(('%sx %s transferred from %s to %s'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id),
 									playerInventory.owner,
-									'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
+									robbery or 'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
 								)
 
 							else

--- a/server.lua
+++ b/server.lua
@@ -220,15 +220,15 @@ ServerCallback.Register('swapItems', function(source, data)
 
 				if toInventory.type == 'player' and fromInventory.type == 'otherplayer' then
 					if shared.isPolice(playerInventory.player.job.name) == false then
-						robbery = '**ITEM ROBBERY**\n'
+						robbery = 'Robbed by'
 					else
-						robbery = '**ITEM CONFISCATION BY POLICE** ('..playerInventory.player.job.name..')\n'
+						robbery = 'Confiscated by ('..playerInventory.player.job.name..')'
 					end
 				elseif toInventory.type == 'otherplayer' and fromInventory.type == 'player' then
 					if shared.isPolice(playerInventory.player.job.name) == false then
-						robbery = '**ITEM PLANTED BY CIVILIAN**\n'
+						robbery = 'Planted by non-police'
 					else
-						robbery = '**ITEM PLANTED BY POLICE** ('..playerInventory.player.job.name..')\n'
+						robbery = 'Planted by police ('..playerInventory.player.job.name..')'
 					end
 				end
 			end
@@ -269,9 +269,9 @@ ServerCallback.Register('swapItems', function(source, data)
 
 								if container then Inventory.ContainerWeight(containerItem, toInventory.type == 'container' and toWeight or fromWeight) end
 
-								Log(('%sx %s transferred from %s to %s for %sx %s'):format(fromData.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id, toData.count, toData.name),
+								Log(('%sx %s %s %s to %s for %sx %s'):format(fromData.count, fromData.name, robbery or 'transferred from', fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id, toData.count, toData.name),
 									playerInventory.owner,
-									robbery or 'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
+									'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
 								)
 
 							else return end
@@ -293,9 +293,9 @@ ServerCallback.Register('swapItems', function(source, data)
 
 								if container then Inventory.ContainerWeight(containerItem, toInventory.type == 'container' and toInventory.weight or fromInventory.weight) end
 
-								Log(('%sx %s transferred from %s to %s'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id),
+								Log(('%sx %s %s %s to %s'):format(data.count, fromData.name, robbery or 'transferred from', fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id),
 									playerInventory.owner,
-									robbery or 'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
+									'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
 								)
 
 							end
@@ -321,9 +321,9 @@ ServerCallback.Register('swapItems', function(source, data)
 
 								if container then Inventory.ContainerWeight(containerItem, toInventory.type == 'container' and toInventory.weight or fromInventory.weight) end
 
-								Log(('%sx %s transferred from %s to %s'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id),
+								Log(('%sx %s %s %s to %s'):format(data.count, fromData.name, robbery or 'transferred from', fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id),
 									playerInventory.owner,
-									robbery or 'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
+									'swapSlots', fromInventory.owner or fromInventory.id, toInventory.owner or toInventory.id
 								)
 
 							else


### PR DESCRIPTION
This adds logging for when police or civilians access another players inventory and move items in or out. You may want to tweak this before merging to fit with the new DataDog integration. I haven't done that yet as I was still using the discord logging.