### PR TITLE
fix(client): Close inventory on item use

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -219,6 +219,7 @@ local function useSlot(slot)
 		if item.metadata.container then
 			return OpenInventory('container', item.slot)
 		elseif data.client then
+			if invOpen and data.close then TriggerEvent('ox_inventory:closeInventory') end
 
 			if data.client.export then
 				if type(data.client.export) ~= 'function' then


### PR DESCRIPTION
Items that only had `export` in client options didn't close the inventory.