### PR TITLE
fix: 'whatever' command running as system command

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -1,5 +1,5 @@
 # Set your resource config in this file, and use 'exec @ox_inventory/config.cfg' rather than directly starting ox_inventory
-# Or put them into your 'server.cfg'; whatever works for you
+# Or put them into your 'server.cfg', whatever works for you
 
 # Activate specific event handlers and functions (supported: esx)
 setr inventory:framework "esx"


### PR DESCRIPTION
I guess semicolon is ending the comment so 'whatever' was run as a command and console would output an error on startup