### PR TITLE
feat(server): Restrictions for containers

### DIFF
--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -2,8 +2,20 @@ local Items = {}
 local ItemList = items()
 
 -- Slot count and maximum weight for containers
+-- Whitelist and blacklist: ['item_name'] = true
 Items.containers = {
-	['paperbag'] = {5, 1000}
+	['paperbag'] = {
+		size = {5, 1000},
+		blacklist = {
+			['testburger'] = true -- No burgers!
+		}
+	},
+	['pizzabox'] = {
+		size = {1, 1000},
+		whitelist = {
+			['pizza'] = true -- Pizza box for pizza only
+		}
+	}
 }
 
 -- Possible metadata when creating garbage
@@ -197,7 +209,7 @@ function Items.Metadata(inv, item, metadata, count)
 		if container then
 			count = 1
 			metadata.container = metadata.container or GenerateText(3)..os.time()
-			metadata.size = container
+			metadata.size = container.size
 		elseif item.name == 'identification' then
 			count = 1
 			if next(metadata) == nil then


### PR DESCRIPTION
Allows containers to contain only specific items set by whitelist or blacklist.

Items listed in `whitelist` table are the only ones that can be moved in the container.
```lua
-- example for wallet
['wallet'] = {
	size = {5, 250},
	whitelist = {
		['money'] = true,
		['identification'] = true,
		['gymcard'] = true,
		['condom'] = true
	}
}
```

<br>

Items listed in `blacklist` table cannot be moved in the container.
```lua
-- example for paperbag
['paperbag'] = {
	size = {5, 1000},
	blacklist = {
		['WEAPON_CARBINERIFLE'] = true,
		['WEAPON_ADVANCEDRIFLE'] = true,
		['WEAPON_SPECIALCARBINE'] = true
	}
}
```