### PR TITLE
(fix) Typo in Inventory server.lua Fixes #532

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -308,7 +308,7 @@ function Inventory.Load(id, invType, owner)
 			if item then
 
 				if v.metadata then
-					v.metadata = Items.CheckMetadata(v.metadata, item. v.name)
+					v.metadata = Items.CheckMetadata(v.metadata, item, v.name)
 				end
 
 				local slotWeight = Inventory.SlotWeight(item, v)


### PR DESCRIPTION
Found a typo that was causing existing inventories stored in the database to not load if they had metadata.