### PR TITLE
Add datadog hostname to config

### DIFF
--- a/modules/logs/server.lua
+++ b/modules/logs/server.lua
@@ -10,7 +10,7 @@ if key ~= '' then
 			print(json.encode(text, {indent=true}), '\n')
 			print(json.encode(header, {indent=true}), '\n')
 		end, 'POST', json.encode({
-			hostname = 'FXServer',
+			hostname = GetConvar('datadog:hostname', 'FXServer'),
 			service = shared.resource,
 			message = message,
 			ddsource = source,


### PR DESCRIPTION
I think it's a good idea to being able to change the datadog hostname, this way you can differentiate one server to an other in your logs (like devServer and LiveServer)
Documentation change : https://github.com/overextended/ox_inventory/pull/556