### PR TITLE
add set datadog:hostname to default cfg

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -155,6 +155,9 @@ set datadog:key ""
 # Set server intake (https://docs.datadoghq.com/api/latest/logs/#send-logs)
 set datadog:site "datadoghq.com"
 
+# Set server hostname
+set datadog:hostname "FXServer"
+
 
 add_principal group.admin ox_inventory
 add_ace resource.ox_inventory command.add_principal allow


### PR DESCRIPTION
documentation change for my pull request : https://github.com/overextended/ox_inventory/pull/555