### PR TITLE
improvement: necessary dependencies

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -16,7 +16,6 @@ dependencies {
 	'/server:5181',
 	'/onesync',
 	'oxmysql',
-	'es_extended',
 	'ox_lib'
 }
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -16,6 +16,8 @@ dependencies {
 	'/server:5181',
 	'/onesync',
 	'oxmysql',
+	'es_extended',
+	'ox_lib'
 }
 
 shared_scripts {


### PR DESCRIPTION
Added two more dependencies to fxmanifest.lua, inventory doesn't work properly without these resources. Also it will force resources to be started before inventory to prevent additional errors and bugs.