### PR TITLE
Check item limit when swapping from player inventory

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -205,24 +205,39 @@ ServerCallback.Register('swapItems', function(source, data)
 				fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
 			end
 
-			if not sameInventory and toInventory.type == 'player' or toInventory.type == 'otherplayer' then
-				local fromData = fromInventory.items[data.fromSlot]
+			if not sameInventory then
+				if fromInventory.type == 'player' then
+					local toData = toInventory.items[data.toSlot]
 
-				if not fromData then
-					TriggerClientEvent('ox_inventory:closeInventory', source, true)
-					return
-				end
+					if toData then
+						local toItem = Items(toData.name)
+						local _, totalCount, _ = Inventory.GetItemSlots(toInventory, toItem, toItem.metadata)
 
-				local fromItem = Items(fromData.name)
-				local _, totalCount, _ = Inventory.GetItemSlots(toInventory, fromItem, fromItem.metadata)
-
-				if fromItem.limit and (totalCount + data.count) > fromItem.limit then
-					if toInventory.type == 'player' then
-						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = shared.locale('cannot_carry_limit', fromItem.limit, fromItem.label)})
-					elseif toInventory.type == 'otherplayer' then
-						TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = shared.locale('cannot_carry_limit_other', fromItem.limit, fromItem.label)})
+						if toItem.limit and (totalCount + data.count) > toItem.limit then
+							TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = shared.locale('cannot_carry_limit', toItem.limit, toItem.label)})
+							return
+						end
 					end
-					return
+
+				elseif toInventory.type == 'player' or toInventory.type == 'otherplayer' then
+					local fromData = fromInventory.items[data.fromSlot]
+
+					if not fromData then
+						TriggerClientEvent('ox_inventory:closeInventory', source, true)
+						return
+					end
+
+					local fromItem = Items(fromData.name)
+					local _, totalCount, _ = Inventory.GetItemSlots(toInventory, fromItem, fromItem.metadata)
+
+					if fromItem.limit and (totalCount + data.count) > fromItem.limit then
+						if toInventory.type == 'player' then
+							TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = shared.locale('cannot_carry_limit', fromItem.limit, fromItem.label)})
+						elseif toInventory.type == 'otherplayer' then
+							TriggerClientEvent('ox_inventory:notify', source, {type = 'error', text = shared.locale('cannot_carry_limit_other', fromItem.limit, fromItem.label)})
+						end
+						return
+					end
 				end
 			end
 


### PR DESCRIPTION
Just realized that there is a way to glitch the item limit.

There is actually 2 ways to swap 2 items when interacting with another inventory:
- If you swap an item with anothrer one, sarting from **another** inventory, the limit is correctly checked and everything is fine.
- If you swap an item with another one, starting from **your** inventory, you'll be able to carry more than the limit.

Here is the reproduce steps:
- Give yourself 1 `water` & 6 `testburger` (testburger **limit is 3**, but using giveitem allows you to carry more),
- Take a vehicle, and put 3 burgers in the trunk,
- Re-open the trunk, just to make sure,
- Try to swap the 3 `testburger` from the trunk, with the `water` = everything is fine, item check works,
- Try to swap your `water` with the 3 `testburger` of the trunk = you now have 6 `testburger`


So Im not sure if this is the correct way to fix it, but it worked fine for me.