### PR TITLE
Show "Copy serial number" button only if serial exists

### DIFF
--- a/data/locales/fr.lua
+++ b/data/locales/fr.lua
@@ -5,7 +5,7 @@ return {
 	['ui_close'] = "Fermer",
 	['ui_drop'] = "Jeter",
 	['ui_removeattachments'] = "Retirer des accessoires",
-	['ui_copy'] = "Copy serial number",
+	['ui_copy'] = "Copier le numéro de série",
 	-- Tooltip
 	['ui_durability'] = "Durabilité",
 	['ui_ammo'] = "Munitions",
@@ -19,7 +19,7 @@ return {
 	['ui_shift_drag'] = "Séparer une pile d'items en 2",
 	['ui_ctrl_shift_lmb'] = "Déplacer rapidement une pile d'items dans un autre inventaire tout en la séparant en 2",
 	['ui_alt_lmb'] = "Utiliser un item rapidement",
-	['ui_ctrl_c'] = "When hovering over a weapon, copies it's serial number",
+	['ui_ctrl_c'] = "En passant la souris sur une arme, copie son numéro de série",
 	--
 	['$'] = "$",
 	['male'] = "Homme",

--- a/web/src/components/inventory/InventoryContext.tsx
+++ b/web/src/components/inventory/InventoryContext.tsx
@@ -65,7 +65,7 @@ const InventoryContext: React.FC<{
           <Item onClick={handleClick} data={{ action: 'drop' }}>
             {Locale.ui_drop}
           </Item>
-          {props.item.name.startsWith('WEAPON_') && props.item.metadata && (
+          {props.item.name.startsWith('WEAPON_') && props.item.metadata?.serial && (
             <>
               <Separator />
               <Item


### PR DESCRIPTION
Without this condition, you can see the button on any weapons (e.g. WEAPON_SWITCHBLADE, which doesn't have any serial number, so it wont copy anything)