### PR TITLE
Fix error server.lua136 table index is nil on additem with a full inv

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -560,13 +560,17 @@ function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 				end
 				slot = toSlot
 			end
+			if slot then
+				Inventory.SetSlot(inv, item, count, metadata, slot)
+				inv.weight = inv.weight + (item.weight + (metadata?.weight or 0)) * count
 
-			Inventory.SetSlot(inv, item, count, metadata, slot)
-			inv.weight = inv.weight + (item.weight + (metadata?.weight or 0)) * count
-
-			if inv.type == 'player' then
-				if shared.framework == 'esx' then Inventory.SyncInventory(inv) end
-				TriggerClientEvent('ox_inventory:updateSlots', inv.id, {{item = inv.items[slot], inventory = inv.type}}, {left=inv.weight, right=inv.open and Inventories[inv.open]?.weight}, count, false)
+				if inv.type == 'player' then
+					if shared.framework == 'esx' then Inventory.SyncInventory(inv) end
+					TriggerClientEvent('ox_inventory:updateSlots', inv.id, {{item = inv.items[slot], inventory = inv.type}}, {left=inv.weight, right=inv.open and Inventories[inv.open]?.weight}, count, false)
+				end
+			else
+				success = false
+				reason = 'inventory_full'
 			end
 		else
 			success = false


### PR DESCRIPTION
We have this error if we use additem command with a full inventory
![FiveM_b2189_GTAProcess_tcu3SdhR53](https://user-images.githubusercontent.com/855331/158889390-3ef30ef6-8a45-4ecd-8997-ca51495a8327.png)
![FiveM_b2189_GTAProcess_ikMQPzyNIA](https://user-images.githubusercontent.com/855331/158889479-72504688-1e68-4784-b639-88344e3a8f49.png)

