### PR TITLE
Fix inventory don't show item if slots are uper then shared.playerslots

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -876,6 +876,13 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 
 	while not uiLoaded do Wait(50) end
 
+	local maxSlots = shared.playerslots
+	if #PlayerData.inventory > shared.playerslots then
+		for k,v in pairs(PlayerData.inventory) do
+			if v.slot > maxSlots then maxSlots = v.slot end
+		end
+	end
+
 	SendNUIMessage({
 		action = 'init',
 		data = {
@@ -883,7 +890,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 			items = ItemData,
 			leftInventory = {
 				id = cache.playerId,
-				slots = shared.playerslots,
+				slots = maxSlots,
 				items = PlayerData.inventory,
 				maxWeight = shared.playerweight,
 			}

--- a/server.lua
+++ b/server.lua
@@ -36,8 +36,20 @@ local function setPlayerInventory(player, data)
 			end
 		end
 	end
+	local maxSlots = shared.playerslots
+	if #inventory > shared.playerslots then
+		local count = 0
+		for k,v in pairs(inventory) do
+			count = count+1
+			if k ~= count then
+				inventory[count] = v
+				inventory[count].slot = count
+			end
+			if v.slot > maxSlots then maxSlots = v.slot  end
+		end
+	end
 
-	local inv = Inventory.Create(player.source, player.name, 'player', shared.playerslots, totalWeight, shared.playerweight, player.identifier, inventory)
+	local inv = Inventory.Create(player.source, player.name, 'player', maxSlots, totalWeight, shared.playerweight, player.identifier, inventory)
 	inv.player = server.setPlayerData(player)
 
 	if shared.framework == 'esx' then Inventory.SyncInventory(inv) end


### PR DESCRIPTION
After convert from an old inventory, players can have item in a slot not valid.
Server global max slots are 20 but player have 30 slots after use convert.lua.
In normal condition the inventory Only show the first 20 slots But the weight of other item are count.

Here the result after this fix
![FiveM_b2189_GTAProcess_UWvPcp4N7J](https://user-images.githubusercontent.com/855331/159049983-cceb42b8-8b88-4df0-9292-ae9acf5f5d55.png)

I have add too a reorder item if the player connect Only in the case of he have more slots then shared.playerslots
![FiveM_b2189_GTAProcess_3avyBd6jm7](https://user-images.githubusercontent.com/855331/159050175-5d6271b3-78c9-4a6c-9346-78c50c96fb3b.png)
![FiveM_b2189_GTAProcess_HhDUuZsotY](https://user-images.githubusercontent.com/855331/159050182-edb22fa1-f7e4-4199-adbc-df4da494b22a.png)


After have play and disconnect with an empty slot the code slowly reduice the inventory to shared.playerslots
