### PR TITLE
fix(server/inventory): fix AddItem success cb

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -570,6 +570,7 @@ function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 			if slot then
 				Inventory.SetSlot(inv, item, count, metadata, slot)
 				inv.weight = inv.weight + (item.weight + (metadata?.weight or 0)) * count
+				success = true
 
 				if inv.type == 'player' then
 					if shared.framework == 'esx' then Inventory.SyncInventory(inv) end


### PR DESCRIPTION
The AddItem cb success variable always returns false, even when successfull, because success is never set to true.
