### PR TITLE
Fix inventory weight check

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -727,7 +727,7 @@ function Inventory.CanCarryItem(inv, item, count, metadata)
 			if count == nil then count = 1 end
 			local newWeight = inv.weight + (item.weight * count)
 
-			if newWeight >= inv.maxWeight then
+			if newWeight > inv.maxWeight then
 				TriggerClientEvent('ox_inventory:notify', inv.id, {type = 'error', text = shared.locale('cannot_carry')})
 				return false
 			end


### PR DESCRIPTION
Inventory.CanCarryItem had an off-by-one issue because it was checking if newweight >= maxweight, should just be newweight > maxweight so you can actually achieve max weight.

I am unsure if this was done on purpose or was an oversight, so far my testing on my server reveals this works as it should as before this change I could only get up to "maxweight - itemweight" for inventory total weight.