### PR TITLE
fix for setjob errors (Markers)

### DIFF
--- a/data/shops.lua
+++ b/data/shops.lua
@@ -143,6 +143,8 @@ return {
 
 	BlackMarketArms = {
 		name = 'Black Market (Arms)',
+		blip = {
+		},
 		inventory = {
 			{ name = 'WEAPON_DAGGER', price = 5000, metadata = { registered = false	}, currency = 'black_money' },
 			{ name = 'WEAPON_CERAMICPISTOL', price = 50000, metadata = { registered = false }, currency = 'black_money' },


### PR DESCRIPTION
There's a little bug when switching jobs, and that's caused by the lack of this code.

![image](https://user-images.githubusercontent.com/87586904/166213500-088860a8-7709-4c73-8728-2ac30489d83c.png)

When printing the blips, the last shop is returned as null.

![image](https://user-images.githubusercontent.com/87586904/166213865-c03eac29-7101-476d-bbb1-5d4b5b4ff548.png)
![image](https://user-images.githubusercontent.com/87586904/166213891-4503a053-aacc-4466-8226-6ff342fe688a.png)


After adding the code, the problem is gone. I hope it will be of great help, greetings.