### PR TITLE
fix (inventory/server): item swap in evidence

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -923,6 +923,16 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 					if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
 						-- Swap items
+						if toInventory.type == 'policeevidence' and not sameInventory then
+							local group, rank = server.hasGroup(toInventory, shared.police)
+			
+							if not group then return end
+
+							if server.evidencegrade > rank then
+								return TriggerClientEvent('ox_lib:notify', source, { type = 'error', description = shared.locale('evidence_cannot_take') })
+							end
+						end
+							
 						local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight)
 						local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight)
 


### PR DESCRIPTION
So i dont think this is the best place to add a check and i feel like it should be done higher but it also needs to be when a swap is detected otherwise it will block any inventory manipulation.
Might not be the best way to do it but still fixes the 'bug' for now.