### PR TITLE
Fixed 'Search' functions only returning single items

### DIFF
--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -62,7 +62,7 @@ function Inventory.Search(search, item, metadata)
 				end
 			end
 		end
-		if next(returnData) then return items == 1 and returnData[item[1]] or returnData end
+		if next(returnData) then return returnData end
 	end
 	return false
 end

--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -54,7 +54,7 @@ function Inventory.Search(search, item, metadata)
 				if v.name == item then
 					if not v.metadata then v.metadata = {} end
 					if not metadata or table.contains(v.metadata, metadata) then
-						if search == 1 then returnData[item][#returnData[item]+1] = PlayerData.inventory[v.slot]
+						if search == 1 then returnData[item][v.slot] = PlayerData.inventory[v.slot]
 						elseif search == 2 then
 							returnData[item] += v.count
 						end

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -638,7 +638,7 @@ function Inventory.Search(inv, search, items, metadata)
 
 						if not metadata or table.contains(v.metadata, metadata) then
 							if search == 1 then
-								returnData[item][#returnData[item]+1] = inv[v.slot]
+								returnData[item][v.slot] = inv[v.slot]
 							elseif search == 2 then
 								returnData[item] += v.count
 							end
@@ -647,7 +647,7 @@ function Inventory.Search(inv, search, items, metadata)
 				end
 			end
 
-			if next(returnData) then return itemCount == 1 and returnData[items[1]] or returnData end
+			if next(returnData) then return returnData end
 		end
 	end
 


### PR DESCRIPTION
- searches were only returning one slot for any item searched, no matter how many individual items were in the inventory. 
- Issue was that the key value it was trying to set in the 'returnData[item]' table was always 1. 
- It has been changed to set the slot number as the key and return the data of all instances of the items.
- Changed the return values so all 'slots' searches return in the same format, for compatability reasons