### PR TITLE
fix (inventoory/weapon): reloading

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1435,12 +1435,19 @@ RegisterServerEvent('ox_inventory:updateWeapon', function(action, value, slot)
 		if weapon and weapon.metadata then
 			local item = Items(weapon.name)
 
+<<<<<<< Updated upstream
 			if not item.weapon then
 				inventory.weapon = nil
 				return
 			end
 
 			if action == 'load' and weapon.metadata.durability > 0 then
+=======
+			if action == 'disarm' then
+				inventory.weapon = nil
+				return
+			elseif action == 'load' and weapon.metadata.durability > 0 then
+>>>>>>> Stashed changes
 				local ammo = Items(weapon.name).ammoname
 				local diff = value - weapon.metadata.ammo
 				Inventory.RemoveItem(inventory, ammo, diff)

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -93,6 +93,7 @@ function Utils.Disarm(currentWeapon, newSlot)
 				Wait(sleep)
 			end
 			Utils.ItemNotify({currentWeapon.label, currentWeapon.name, shared.locale('holstered')})
+			TriggerServerEvent('ox_inventory:updateWeapon', 'disarm', nil, currentWeapon.slot)
 		end
 
 		RemoveAllPedWeapons(cache.ped, true)


### PR DESCRIPTION
Inventory.weapon wasnt being removed when player died or used Utils:disarm
I dont think thats the best way of fixing it but it works.