### PR TITLE
Fix fire cannon not working properly

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -837,7 +837,7 @@ lib.onCache('seat', function(seat)
 
 				if seat == -1 then
 					if vehicleModel == `firetruk` then
-						SetCurrentPedVehicleWeapon(cache.ped, 1422046295)
+						SetCurrentPedVehicleWeapon(cache.ped, `WATER_CANNON`)
 					end
 				end
 			else Utils.WeaponWheel(false) end

--- a/client.lua
+++ b/client.lua
@@ -837,7 +837,7 @@ lib.onCache('seat', function(seat)
 
 				if seat == -1 then
 					if vehicleModel == `firetruk` then
-						SetCurrentPedVehicleWeapon(cache.ped, `VEHICLE_WEAPON_WATER_CANNON`)
+						SetCurrentPedVehicleWeapon(cache.ped, 1422046295)
 					end
 				end
 			else Utils.WeaponWheel(false) end


### PR DESCRIPTION
The hash of VEHICLE_WEAPON_WATER_CANNON is not 1422046295, and the new way is not working. Reverted to the old hash.