### PR TITLE
fix(server): Check for empty table

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -19,7 +19,7 @@ function server.setPlayerInventory(player, data)
 	local inventory = {}
 	local totalWeight = 0
 
-	if data then
+	if data and table.type(data) ~= 'empty' then
 		local ostime = os.time()
 
 		if table.type(data) == 'array' then


### PR DESCRIPTION
* Ran into an issue locally where data being an empty table would lead to ox_inventory thinking there was a malformed inventory that was attempting to be converted