### PR TITLE
Feat: Support modular weapon attachments + change metadata component structure

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1537,9 +1537,25 @@ RegisterServerEvent('ox_inventory:updateWeapon', function(action, value, slot, d
 					table.remove(weapon.metadata.components, value)
 					weapon.weight = Inventory.SlotWeight(item, weapon)
 				elseif type == 'string' then
+					local newComponents = {}
+					for k,v in pairs(data) do
+						local thisComponent = {name = v.name, hash = {}}
+						if not Items(v.name) or not v.name:find("at_") then
+							return
+						end
+						for _,hash in pairs(v.hash) do
+							if tonumber(hash) then
+								table.insert(thisComponent.hash, hash)
+							end
+						end
+
+						table.insert(newComponents, thisComponent)
+					end
+
 					local component = inventory.items[tonumber(value)]
+
 					Inventory.RemoveItem(inventory, component.name, 1)
-					weapon.metadata.components = data
+					weapon.metadata.components = newComponents
 					weapon.weight = Inventory.SlotWeight(item, weapon)
 				end
 				syncInventory = true

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -201,7 +201,7 @@ function Inventory.SlotWeight(item, slot)
 
 	if slot.metadata.components then
 		for i = 1, #slot.metadata.components do
-			weight += Items(slot.metadata.components[i]).weight
+			weight += Items(slot.metadata.components[i].name).weight
 		end
 	end
 
@@ -1484,7 +1484,7 @@ RegisterServerEvent('ox_inventory:giveItem', function(slot, target, count)
 	end
 end)
 
-RegisterServerEvent('ox_inventory:updateWeapon', function(action, value, slot)
+RegisterServerEvent('ox_inventory:updateWeapon', function(action, value, slot, data)
 	local inventory = Inventories[source]
 
 	if not inventory then return end
@@ -1533,13 +1533,13 @@ RegisterServerEvent('ox_inventory:updateWeapon', function(action, value, slot)
 				Inventory.RemoveItem(inventory, weapon.name, 1, weapon.metadata, weapon.slot)
 			elseif action == 'component' then
 				if type == 'number' then
-					Inventory.AddItem(inventory, weapon.metadata.components[value], 1)
+					Inventory.AddItem(inventory, weapon.metadata.components[value].name, 1)
 					table.remove(weapon.metadata.components, value)
 					weapon.weight = Inventory.SlotWeight(item, weapon)
 				elseif type == 'string' then
 					local component = inventory.items[tonumber(value)]
 					Inventory.RemoveItem(inventory, component.name, 1)
-					table.insert(weapon.metadata.components, component.name)
+					weapon.metadata.components = data
 					weapon.weight = Inventory.SlotWeight(item, weapon)
 				end
 				syncInventory = true

--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -333,6 +333,9 @@ function Items.CheckMetadata(metadata, item, name, ostime)
 			local components = {}
 			local size = 0
 			for _, component in pairs(metadata.components) do
+				if type(component) == "string" then
+					component = {name = component, hash = {}}
+				end
 				if component and ItemList[component.name] then
 					size += 1
 					components[size] = component.name

--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -321,6 +321,10 @@ function Items.CheckMetadata(metadata, item, name, ostime)
 	if metadata.components then
 		if table.type(metadata.components) == 'array' then
 			for i = 1, #metadata.components do
+				if type(metadata.components[i]) == "string" then
+					metadata.components[i] = {name = metadata.components[i], hash = {}}
+				end
+
 				if not ItemList[metadata.components[i].name] then
 					table.remove(metadata.components, i)
 				end

--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -321,7 +321,7 @@ function Items.CheckMetadata(metadata, item, name, ostime)
 	if metadata.components then
 		if table.type(metadata.components) == 'array' then
 			for i = 1, #metadata.components do
-				if not ItemList[metadata.components[i]] then
+				if not ItemList[metadata.components[i].name] then
 					table.remove(metadata.components, i)
 				end
 			end
@@ -329,9 +329,9 @@ function Items.CheckMetadata(metadata, item, name, ostime)
 			local components = {}
 			local size = 0
 			for _, component in pairs(metadata.components) do
-				if component and ItemList[component] then
+				if component and ItemList[component.name] then
 					size += 1
-					components[size] = component
+					components[size] = component.name
 				end
 			end
 			metadata.components = components

--- a/modules/weapon/client.lua
+++ b/modules/weapon/client.lua
@@ -46,7 +46,7 @@ function Weapon.Equip(item, data)
 
 	if item.metadata.components then
 		for i = 1, #item.metadata.components do
-			local components = Items[item.metadata.components[i]].client.component
+			local components = Items[item.metadata.components[i].name].client.component
 			for v=1, #components do
 				local component = components[v]
 				if DoesWeaponTakeWeaponComponent(data.hash, component) then

--- a/web/src/components/inventory/InventoryContext.tsx
+++ b/web/src/components/inventory/InventoryContext.tsx
@@ -78,9 +78,9 @@ const InventoryContext: React.FC = () => {
         {item && item.metadata?.components && item.metadata?.components.length > 0 && (
           <NestedMenuItem parentMenuOpen={!!contextMenu} label={Locale.ui_removeattachments}>
             {item &&
-              item.metadata?.components.map((component: string, index: number) => (
-                <MenuItem key={index} onClick={() => handleClick({ action: 'remove', component, slot: item.slot })}>
-                  {Items[component]?.label}
+              item.metadata?.components.map((component: {name: string, hash: number[]}, index: number) => (
+                <MenuItem key={index} onClick={() => handleClick({ action: 'remove', component: component.name, slot: item.slot })}>
+                  {Items[component.name]?.label}
                 </MenuItem>
               ))}
           </NestedMenuItem>

--- a/web/src/components/inventory/SlotTooltip.tsx
+++ b/web/src/components/inventory/SlotTooltip.tsx
@@ -42,9 +42,9 @@ const SlotTooltip: React.FC<{ item: Slot }> = ({ item }) => {
       )}
       {item.metadata?.components && item.metadata?.components[0] && (
         <p>
-          {Locale.ui_components}:{' '}
-          {(item.metadata?.components).map((component: string, index: number, array: []) =>
-            index + 1 === array.length ? Items[component]?.label : Items[component]?.label + ', '
+        {Locale.ui_components}:{' '}
+          {(item.metadata?.components).map((component: {name: string, hash: number[]}, index: number, array: []) =>
+            index + 1 === array.length ? Items[component.name]?.label : Items[component.name]?.label + ', '
           )}
         </p>
       )}


### PR DESCRIPTION
This _shouldn't_ be breaking anything with the current weapons components as i used the 'checkMetadata' function to change it structure to the new one. Obviously the hash will be empty but removing then adding the component will fix it. It also shouldn't be an issue in any ways as the hash is not currently used internally the add/remove component function works pretty much the same.

Some modular addon weapons requires multiples components at the same time.
ex: Sniper scopes also needs a rail, some silencer also needs a barrel ect.
So being able to add multiple component with only using one is a must in those situations.

The metadata structure change is because when trying to access weapon components from another resource its really annoying to retrieve the component hash used.
ex: When trying to recreate the weapon as a weapon object.