### PR TITLE
Fix: putting overweight items in container

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1083,7 +1083,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 						local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight)
 
 						if not sameInventory then
-							if fromInventory.type == 'container' or (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
+							if (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
 								fromInventory.weight = fromWeight
 								toInventory.weight = toWeight
 


### PR DESCRIPTION
**When you swap items from container to inventory you can put overweight item in the container.**
**[Originally](https://streamable.com/2i3tbb)**
**[Edited](https://streamable.com/5cqjmy)**