### PR TITLE
fix(client): Update Reload weapon keybind name

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -590,7 +590,7 @@ local function registerCommands()
 	})
 
 	lib.addKeybind({
-		name = 'reload',
+		name = 'reloadweapon',
 		description = locale('reload_weapon'),
 		defaultKey = 'r',
 		onPressed = function(self)


### PR DESCRIPTION
* ~~Appears that pefcl has a conflicting keybind which was~~ Players are unable to reload with default keybind 'R'. Updating the keybind name appears to resolve the issue.