### PR TITLE
Allow GetItem to return Metadata and item slot

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -582,6 +582,10 @@ function Inventory.GetItem(inv, item, metadata, returnsCount)
 			for _, v in pairs(inv.items) do
 				if v and v.name == item.name and (not metadata or table.contains(v.metadata, metadata)) then
 					count += v.count
+					
+					item.slot = v.slot
+					item.metadata = v.metadata or {}
+					
 					local durability = v.metadata.durability
 
 					if durability and durability > 100 and ostime >= durability then


### PR DESCRIPTION
I recently switched from QBCore inventory and found this export to be lacking, I might simply be wrong and there's a better way to do this but I've been using this for a few days and found no issues so thought I'd share.