### PR TITLE
Skillcheck enabled crafting

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1350,7 +1350,7 @@ end)
 
 lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
 	recipe = client.craftingBenches[id].items[recipe]
-	if not recipe.difficulty then
+	if not recipe.difficulty  then
 		return lib.progressCircle({
 			label = locale('crafting_item', Items[recipe.name].label),
 			duration = recipe.duration or 3000,
@@ -1365,8 +1365,7 @@ lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
 			}
 		})
 	else
-		local success = lib.skillCheck(recipe.difficulty)
-		if success then
+		if recipe.difficulty and lib.skillCheck(recipe.difficulty) then 
 			return lib.progressCircle({
 				label = locale('crafting_item', Items[recipe.name].label),
 				duration = recipe.duration or 3000,
@@ -1381,6 +1380,8 @@ lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
 				}
 			})
 		end
+	end	
+end)
 	end
 	
 end)

--- a/client.lua
+++ b/client.lua
@@ -1350,20 +1350,39 @@ end)
 
 lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
 	recipe = client.craftingBenches[id].items[recipe]
-
-	return lib.progressCircle({
-		label = locale('crafting_item', Items[recipe.name].label),
-		duration = recipe.duration or 3000,
-		canCancel = true,
-		disable = {
-			move = true,
-			combat = true,
-		},
-		anim = {
-			dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
-			clip = 'machinic_loop_mechandplayer',
-		}
-	})
+	if not recipe.difficulty then
+		return lib.progressCircle({
+			label = locale('crafting_item', Items[recipe.name].label),
+			duration = recipe.duration or 3000,
+			canCancel = true,
+			disable = {
+				move = true,
+				combat = true,
+			},
+			anim = {
+				dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
+				clip = 'machinic_loop_mechandplayer',
+			}
+		})
+	else
+		local success = lib.skillCheck(recipe.difficulty)
+		if success then
+			return lib.progressCircle({
+				label = locale('crafting_item', Items[recipe.name].label),
+				duration = recipe.duration or 3000,
+				canCancel = true,
+				disable = {
+					move = true,
+					combat = true,
+				},
+				anim = {
+					dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
+					clip = 'machinic_loop_mechandplayer',
+				}
+			})
+		end
+	end
+	
 end)
 
 ---Synchronise and validate all item movement between the NUI and server.

--- a/client.lua
+++ b/client.lua
@@ -1351,39 +1351,10 @@ end)
 lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
 	recipe = client.craftingBenches[id].items[recipe]
 	if not recipe.difficulty  then
-		return lib.progressCircle({
-			label = locale('crafting_item', Items[recipe.name].label),
-			duration = recipe.duration or 3000,
-			canCancel = true,
-			disable = {
-				move = true,
-				combat = true,
-			},
-			anim = {
-				dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
-				clip = 'machinic_loop_mechandplayer',
-			}
-		})
-	else
-		if recipe.difficulty and lib.skillCheck(recipe.difficulty) then 
-			return lib.progressCircle({
-				label = locale('crafting_item', Items[recipe.name].label),
-				duration = recipe.duration or 3000,
-				canCancel = true,
-				disable = {
-					move = true,
-					combat = true,
-				},
-				anim = {
-					dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
-					clip = 'machinic_loop_mechandplayer',
-				}
-			})
-		end
+		return lib.progressCircle({label = locale('crafting_item', Items[recipe.name].label),duration = recipe.duration or 3000,canCancel = true,disable = {move = true,combat = true,},anim = {dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',clip = 'machinic_loop_mechandplayer',}})
+	elseif recipe.difficulty and lib.skillCheck(recipe.difficulty) then
+		return lib.progressCircle({label = locale('crafting_item', Items[recipe.name].label),duration = recipe.duration or 3000,canCancel = true,disable = {move = true,combat = true,},anim = {dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',clip = 'machinic_loop_mechandplayer',}})
 	end	
-end)
-	end
-	
 end)
 
 ---Synchronise and validate all item movement between the NUI and server.

--- a/data/crafting.lua
+++ b/data/crafting.lua
@@ -8,6 +8,7 @@ return {
 					WEAPON_HAMMER = 0.1
 				},
 				duration = 5000,
+				difficulty = {'easy', 'medium', 'hard'},
 				count = 3,
 				metadata = { durability = 20 }
 			},


### PR DESCRIPTION
Modified ox_inventory:startCrafting in client.lua to accept skill check options in data/crafting.lua, which will continue crafting normally if no skillcheck difficulty is indicated, and will show the progressbar after the skillcheck so it can still be cancelled.

May not be the best implementation due to the repeated callout of the lib.progressCircle, feedback is appreciated.

