### PR TITLE
Fix for floating point number precision error in inventory GUI

### DIFF
--- a/web/src/components/inventory/InventoryGrid.tsx
+++ b/web/src/components/inventory/InventoryGrid.tsx
@@ -8,7 +8,7 @@ import { createPortal } from 'react-dom';
 
 const InventoryGrid: React.FC<{ inventory: Inventory }> = ({ inventory }) => {
   const weight = React.useMemo(
-    () => (inventory.maxWeight !== undefined ? getTotalWeight(inventory.items) : 0),
+    () => (inventory.maxWeight !== undefined ? Math.floor(getTotalWeight(inventory.items)*1000)/1000 : 0),
     [inventory.maxWeight, inventory.items]
   );
 


### PR DESCRIPTION
Due to the floating point number precision error the inventory weight can be displayed incorrectly.
Example:
![image](https://user-images.githubusercontent.com/37124195/207654852-798efa5c-14c2-496d-9b9f-004ef67c502e.png)

This pull request rounds the weight displayed to the player in the inventory GUI down to the nearest gram `0.001` to fix the floating point number precision error being displayed to players. The value in the example would be rounded to `12.765`
This change only affects the GUI displayed to players, not any internal values.