### PR TITLE
feat(web): Metadata image URL support (png & apng)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,10 @@ debugData([
             metadata: { description: 'Generic item description' },
           },
           { slot: 5, name: 'water', weight: 100, count: 1 },
+          { slot: 6, name: 'backwoods', weight: 100, count: 1, metadata: {
+            label: 'Russian Cream',
+            image: "https://i.imgur.com/2xHhTTz.png"
+          }},
         ],
       },
       rightInventory: {

--- a/web/src/components/inventory/InventoryHotbar.tsx
+++ b/web/src/components/inventory/InventoryHotbar.tsx
@@ -31,7 +31,7 @@ const InventoryHotbar: React.FC = () => {
           <div
             className="hotbar-item-slot"
             style={{
-              backgroundImage: `url(${checkimage(item)})`,
+              backgroundImage: `url(${checkimage(item.metadata?.image ? item.metadata.image : item.name)})`,
             }}
             key={`hotbar-${item.slot}`}
           >

--- a/web/src/components/inventory/InventoryHotbar.tsx
+++ b/web/src/components/inventory/InventoryHotbar.tsx
@@ -6,7 +6,7 @@ import WeightBar from '../utils/WeightBar';
 import { Slide } from '@mui/material';
 import { useAppSelector } from '../../store';
 import { selectLeftInventory } from '../../store/inventory';
-import { imagepath } from '../../store/imagepath';
+import { checkimage } from '../../store/imagepath';
 
 const InventoryHotbar: React.FC = () => {
   const [hotbarVisible, setHotbarVisible] = useState(false);
@@ -31,7 +31,7 @@ const InventoryHotbar: React.FC = () => {
           <div
             className="hotbar-item-slot"
             style={{
-              backgroundImage: `url(${`${imagepath}/${item.metadata?.image ? item.metadata.image : item.name}.png`})`,
+              backgroundImage: `url(${checkimage(item)})`,
             }}
             key={`hotbar-${item.slot}`}
           >

--- a/web/src/components/inventory/InventorySlot.tsx
+++ b/web/src/components/inventory/InventorySlot.tsx
@@ -13,7 +13,7 @@ import { Locale } from '../../store/locale';
 import { Tooltip } from '@mui/material';
 import SlotTooltip from './SlotTooltip';
 import { setContextMenu } from '../../store/inventory';
-import { imagepath } from '../../store/imagepath';
+import { imagepath, checkimage } from '../../store/imagepath';
 import { onCraft } from '../../dnd/onCraft';
 
 interface SlotProps {
@@ -127,7 +127,7 @@ const InventorySlot: React.FC<SlotProps> = ({ inventory, item }) => {
               ? 'brightness(80%) grayscale(100%)'
               : undefined,
           opacity: isDragging ? 0.4 : 1.0,
-          backgroundImage: `url(${`${imagepath}/${item.metadata?.image ? item.metadata.image : item.name}.png`})`,
+          backgroundImage: `url(${checkimage(item)})`,
           border: isOver ? '1px dashed rgba(255,255,255,0.4)' : '',
         }}
       >

--- a/web/src/components/inventory/InventorySlot.tsx
+++ b/web/src/components/inventory/InventorySlot.tsx
@@ -127,7 +127,7 @@ const InventorySlot: React.FC<SlotProps> = ({ inventory, item }) => {
               ? 'brightness(80%) grayscale(100%)'
               : undefined,
           opacity: isDragging ? 0.4 : 1.0,
-          backgroundImage: `url(${checkimage(item)})`,
+          backgroundImage: `url(${checkimage(item.metadata?.image ? item.metadata.image : item.name)})`,
           border: isOver ? '1px dashed rgba(255,255,255,0.4)' : '',
         }}
       >

--- a/web/src/components/utils/DragPreview.tsx
+++ b/web/src/components/utils/DragPreview.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject, useRef } from 'react';
 import { DragLayerMonitor, useDragLayer, XYCoord } from 'react-dnd';
 import { DragSource } from '../../typings';
-import { imagepath } from '../../store/imagepath';
+import { checkimage } from '../../store/imagepath';
 
 interface DragLayerProps {
   data: DragSource;
@@ -57,7 +57,7 @@ const DragPreview: React.FC = () => {
           ref={element}
           style={{
             transform: `translate(${currentOffset.x}px, ${currentOffset.y}px)`,
-            backgroundImage: `url(${`${imagepath}/${data.image || data.item.name}.png`})`,
+            backgroundImage: `url(${checkimage(data?.image ? data.image : data.item.name)})`,
           }}
         />
       )}

--- a/web/src/components/utils/ItemNotifications.tsx
+++ b/web/src/components/utils/ItemNotifications.tsx
@@ -5,7 +5,7 @@ import useNuiEvent from '../../hooks/useNuiEvent';
 import { Fade } from '@mui/material';
 import useQueue from '../../hooks/useQueue';
 import { Locale } from '../../store/locale';
-import { imagepath } from '../../store/imagepath';
+import { checkimage } from '../../store/imagepath';
 
 interface ItemNotificationProps {
   label: string;
@@ -29,7 +29,7 @@ const ItemNotification = React.forwardRef(
       <div
         className="item-notification-item-box"
         style={{
-          backgroundImage: `url(${`${imagepath}/${props.item.image}.png`})` || 'none',
+          backgroundImage: `url(${checkimage(props.item.image)})` || 'none',
           ...props.style,
         }}
         ref={ref}

--- a/web/src/store/imagepath.ts
+++ b/web/src/store/imagepath.ts
@@ -3,3 +3,12 @@ export let imagepath = 'images';
 export function setImagePath(path: string) {
   if (path && path !== '') imagepath = path;
 }
+
+export const checkimage = (item: any) => {
+  let image = item.name;
+  if(item.metadata?.image){
+    image = item.metadata.image;
+    if(/^https:\/\/.+(\.png|\.apng)$/.test(image)) return image;  
+  }
+  return (`${imagepath}/${image}.png`);
+}

--- a/web/src/store/imagepath.ts
+++ b/web/src/store/imagepath.ts
@@ -4,11 +4,7 @@ export function setImagePath(path: string) {
   if (path && path !== '') imagepath = path;
 }
 
-export const checkimage = (item: any) => {
-  let image = item.name;
-  if(item.metadata?.image){
-    image = item.metadata.image;
-    if(/^https:\/\/.+(\.png|\.apng)$/.test(image)) return image;  
-  }
+export const checkimage = (image: string) => {
+  if(/^https:\/\/.+(\.png|\.apng)$/.test(image)) return image;
   return (`${imagepath}/${image}.png`);
 }


### PR DESCRIPTION
This pull request introduces the ability for script creators to include images in their scripts by specifying a web-hosted URL. This feature can be useful in a variety of situations, such as a business system that allows users to create new menu items on-demand. As an example, I have added a new item to the default web development inventory that demonstrates how to use this feature, but I can remove it if desired. Please let me know if you have any questions or concerns about this change.