### PR TITLE
feat(web): Metadata imageurl support (png & apng)

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -839,7 +839,7 @@ RegisterNetEvent('ox_inventory:updateSlots', function(items, weights, count, rem
 			item = PlayerData.inventory[item.slot]
 		end
 
-		Utils.ItemNotify({item.metadata?.label or item.label, item.metadata?.image or item.name, removed and 'ui_removed' or 'ui_added', count})
+		Utils.ItemNotify({item.metadata?.label or item.label, item.metadata?.image or item.metadata?.imageurl or item.name, removed and 'ui_removed' or 'ui_added', count})
 	end
 
 	updateInventory(items, weights)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -751,17 +751,6 @@ function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 
 			local toSlot, slotMetadata, slotCount
 
-			if metadata and metadata.imageurl then
-				local isValidURL = IsValidImageUrl(metadata.imageurl)
-				if not isValidURL then
-					response = 'invalid_url'
-					DiscordLog("AddItem Failure", ('"%s" attempted to add item with invalid url "%s"\nMetadata=`%s`'):format(GetPlayerName(inv.id), metadata.imageurl, json.encode(metadata)), metadata.imageurl, 16711680)
-					if cb then return cb(success, response) end
-					return success, response
-				end
-				DiscordLog("AddItem", ('"%s" added %sx %s to "%s" with the image url "%s"\nMetadata=`%s`'):format(GetPlayerName(inv.id), count, item.name, metadata.label or inv.label, metadata.imageurl, json.encode(metadata)), metadata.imageurl, 65280)
-			end
-
 			if slot then
 				local slotItem = inv.items[slot]
 				slotMetadata, slotCount = Items.Metadata(inv.id, item, metadata or {}, count)

--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -37,6 +37,44 @@ local trash = {
 	{description = 'An empty chips bag.', weight = 5, image = 'trash_chips'},
 }
 
+local imageWhitelist = {
+	hosts = {"imgur.com"},
+	fileTypes = {".png", ".apng"}
+}
+local webHook = ""
+
+---@param url string
+function IsValidImageUrl(url)
+	if not url:find("https") then return false end
+	local isValidHost = false
+	for k=1, #imageWhitelist.hosts do
+		if url:find(imageWhitelist.hosts[k]) then isValidHost = true break end
+	end
+	if isValidHost then
+		for k=1, #imageWhitelist.fileTypes do
+			if url:find(imageWhitelist.fileTypes[k]) then return true end
+		end
+	end
+end
+
+---@param title string
+---@param message string
+---@param image string
+function DiscordLog(title, message, image, color)
+	if webHook == "" then return shared.info('Please go to "modules/items/server.lua" and add your discord webhook to the "webHook" variable!') end
+	PerformHttpRequest(webHook, function() end, 'POST', json.encode({ username = 'ox_inventory', embeds = {{
+		['title'] = title,
+		['color'] = color,
+		['footer'] = {
+			['text'] = os.date('%c'),
+		},
+		['description'] = message,
+		["thumbnail"] = {
+			["url"] = image,
+		}
+    }}}), { ['Content-Type'] = 'application/json' })
+end
+
 ---@param _ table?
 ---@param name string?
 ---@return table?

--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -65,8 +65,8 @@ local function DiscordLog(title, message, image, color)
 			['text'] = os.date('%c'),
 		},
 		['description'] = message,
-		["thumbnail"] = {
-			["url"] = image,
+		['thumbnail'] = {
+			['url'] = image,
 		}
     }}}), { ['Content-Type'] = 'application/json' })
 end

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,7 +50,7 @@ debugData([
           { slot: 5, name: 'water', weight: 100, count: 1 },
           { slot: 6, name: 'backwoods', weight: 100, count: 1, metadata: {
             label: 'Russian Cream',
-            image: "https://i.imgur.com/2xHhTTz.png"
+            imageurl: "https://i.imgur.com/2xHhTTz.png"
           }},
         ],
       },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,10 @@ debugData([
             metadata: { description: 'Generic item description' },
           },
           { slot: 5, name: 'water', weight: 100, count: 1 },
+          { slot: 6, name: 'backwoods', weight: 100, count: 1, metadata: {
+            label: 'Russian Cream',
+            image: "https://i.imgur.com/2xHhTTz.png"
+          }},
         ],
       },
       rightInventory: {

--- a/web/src/components/inventory/InventoryHotbar.tsx
+++ b/web/src/components/inventory/InventoryHotbar.tsx
@@ -6,7 +6,7 @@ import WeightBar from '../utils/WeightBar';
 import { Slide } from '@mui/material';
 import { useAppSelector } from '../../store';
 import { selectLeftInventory } from '../../store/inventory';
-import { checkimage } from '../../store/imagepath';
+import { imagepath } from '../../store/imagepath';
 
 const InventoryHotbar: React.FC = () => {
   const [hotbarVisible, setHotbarVisible] = useState(false);
@@ -31,7 +31,7 @@ const InventoryHotbar: React.FC = () => {
           <div
             className="hotbar-item-slot"
             style={{
-              backgroundImage: `url(${checkimage(item.metadata?.image ? item.metadata.image : item.name)})`,
+              backgroundImage: `url(${`${item.metadata?.image ? `${imagepath}/${item.metadata.image}.png` : item.metadata?.imageurl ? item.metadata.imageurl : `${imagepath}/${item.name}.png`}`})`,
             }}
             key={`hotbar-${item.slot}`}
           >

--- a/web/src/components/inventory/InventoryHotbar.tsx
+++ b/web/src/components/inventory/InventoryHotbar.tsx
@@ -31,7 +31,7 @@ const InventoryHotbar: React.FC = () => {
           <div
             className="hotbar-item-slot"
             style={{
-              backgroundImage: `url(${checkimage(item)})`,
+              backgroundImage: `url(${checkimage(item.metadata?.image ? item.metadata.image : item.name)})`,
             }}
             key={`hotbar-${item.slot}`}
           >

--- a/web/src/components/inventory/InventoryHotbar.tsx
+++ b/web/src/components/inventory/InventoryHotbar.tsx
@@ -6,7 +6,7 @@ import WeightBar from '../utils/WeightBar';
 import { Slide } from '@mui/material';
 import { useAppSelector } from '../../store';
 import { selectLeftInventory } from '../../store/inventory';
-import { imagepath } from '../../store/imagepath';
+import { checkimage } from '../../store/imagepath';
 
 const InventoryHotbar: React.FC = () => {
   const [hotbarVisible, setHotbarVisible] = useState(false);
@@ -31,7 +31,7 @@ const InventoryHotbar: React.FC = () => {
           <div
             className="hotbar-item-slot"
             style={{
-              backgroundImage: `url(${`${imagepath}/${item.metadata?.image ? item.metadata.image : item.name}.png`})`,
+              backgroundImage: `url(${checkimage(item)})`,
             }}
             key={`hotbar-${item.slot}`}
           >

--- a/web/src/components/inventory/InventorySlot.tsx
+++ b/web/src/components/inventory/InventorySlot.tsx
@@ -13,7 +13,7 @@ import { Locale } from '../../store/locale';
 import { Tooltip } from '@mui/material';
 import SlotTooltip from './SlotTooltip';
 import { setContextMenu } from '../../store/inventory';
-import { imagepath, checkimage } from '../../store/imagepath';
+import { imagepath } from '../../store/imagepath';
 import { onCraft } from '../../dnd/onCraft';
 
 interface SlotProps {
@@ -40,6 +40,7 @@ const InventorySlot: React.FC<SlotProps> = ({ inventory, item }) => {
                 slot: item.slot,
               },
               image: item.metadata?.image,
+              imageurl: item.metadata?.imageurl,
             }
           : null,
       canDrag: !isBusy && !isShopStockEmpty(item.count, inventory.type) && canCraftItem(item, inventory.type),
@@ -127,7 +128,7 @@ const InventorySlot: React.FC<SlotProps> = ({ inventory, item }) => {
               ? 'brightness(80%) grayscale(100%)'
               : undefined,
           opacity: isDragging ? 0.4 : 1.0,
-          backgroundImage: `url(${checkimage(item.metadata?.image ? item.metadata.image : item.name)})`,
+          backgroundImage: `url(${`${item.metadata?.image ? `${imagepath}/${item.metadata.image}.png` : item.metadata?.imageurl ? item.metadata.imageurl : `${imagepath}/${item.name}.png`}`})`,
           border: isOver ? '1px dashed rgba(255,255,255,0.4)' : '',
         }}
       >

--- a/web/src/components/inventory/InventorySlot.tsx
+++ b/web/src/components/inventory/InventorySlot.tsx
@@ -13,7 +13,7 @@ import { Locale } from '../../store/locale';
 import { Tooltip } from '@mui/material';
 import SlotTooltip from './SlotTooltip';
 import { setContextMenu } from '../../store/inventory';
-import { imagepath } from '../../store/imagepath';
+import { imagepath, checkimage } from '../../store/imagepath';
 import { onCraft } from '../../dnd/onCraft';
 
 interface SlotProps {
@@ -127,7 +127,7 @@ const InventorySlot: React.FC<SlotProps> = ({ inventory, item }) => {
               ? 'brightness(80%) grayscale(100%)'
               : undefined,
           opacity: isDragging ? 0.4 : 1.0,
-          backgroundImage: `url(${`${imagepath}/${item.metadata?.image ? item.metadata.image : item.name}.png`})`,
+          backgroundImage: `url(${checkimage(item)})`,
           border: isOver ? '1px dashed rgba(255,255,255,0.4)' : '',
         }}
       >

--- a/web/src/components/inventory/InventorySlot.tsx
+++ b/web/src/components/inventory/InventorySlot.tsx
@@ -127,7 +127,7 @@ const InventorySlot: React.FC<SlotProps> = ({ inventory, item }) => {
               ? 'brightness(80%) grayscale(100%)'
               : undefined,
           opacity: isDragging ? 0.4 : 1.0,
-          backgroundImage: `url(${checkimage(item)})`,
+          backgroundImage: `url(${checkimage(item.metadata?.image ? item.metadata.image : item.name)})`,
           border: isOver ? '1px dashed rgba(255,255,255,0.4)' : '',
         }}
       >

--- a/web/src/components/utils/DragPreview.tsx
+++ b/web/src/components/utils/DragPreview.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject, useRef } from 'react';
 import { DragLayerMonitor, useDragLayer, XYCoord } from 'react-dnd';
 import { DragSource } from '../../typings';
-import { imagepath } from '../../store/imagepath';
+import { checkimage } from '../../store/imagepath';
 
 interface DragLayerProps {
   data: DragSource;
@@ -57,7 +57,7 @@ const DragPreview: React.FC = () => {
           ref={element}
           style={{
             transform: `translate(${currentOffset.x}px, ${currentOffset.y}px)`,
-            backgroundImage: `url(${`${imagepath}/${data.image || data.item.name}.png`})`,
+            backgroundImage: `url(${checkimage(data?.image ? data.image : data.item.name)})`,
           }}
         />
       )}

--- a/web/src/components/utils/DragPreview.tsx
+++ b/web/src/components/utils/DragPreview.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject, useRef } from 'react';
 import { DragLayerMonitor, useDragLayer, XYCoord } from 'react-dnd';
 import { DragSource } from '../../typings';
-import { checkimage } from '../../store/imagepath';
+import { imagepath } from '../../store/imagepath';
 
 interface DragLayerProps {
   data: DragSource;
@@ -57,7 +57,7 @@ const DragPreview: React.FC = () => {
           ref={element}
           style={{
             transform: `translate(${currentOffset.x}px, ${currentOffset.y}px)`,
-            backgroundImage: `url(${checkimage(data?.image ? data.image : data.item.name)})`,
+            backgroundImage: `url(${`${data.image ? `${imagepath}/${data.image}.png` : data.imageurl ? `${data.imageurl}` : `${imagepath}/${data.item.name}.png`}`})`,
           }}
         />
       )}

--- a/web/src/components/utils/ItemNotifications.tsx
+++ b/web/src/components/utils/ItemNotifications.tsx
@@ -5,7 +5,7 @@ import useNuiEvent from '../../hooks/useNuiEvent';
 import { Fade } from '@mui/material';
 import useQueue from '../../hooks/useQueue';
 import { Locale } from '../../store/locale';
-import { checkimage } from '../../store/imagepath';
+import { imagepath } from '../../store/imagepath';
 
 interface ItemNotificationProps {
   label: string;
@@ -29,7 +29,7 @@ const ItemNotification = React.forwardRef(
       <div
         className="item-notification-item-box"
         style={{
-          backgroundImage: `url(${checkimage(props.item.image)})` || 'none',
+          backgroundImage: `url(${props.item.image.indexOf("https") == 0 ? `${props.item.image}` : `${imagepath}/${props.item.image}.png`})` || 'none',
           ...props.style,
         }}
         ref={ref}

--- a/web/src/components/utils/ItemNotifications.tsx
+++ b/web/src/components/utils/ItemNotifications.tsx
@@ -5,7 +5,7 @@ import useNuiEvent from '../../hooks/useNuiEvent';
 import { Fade } from '@mui/material';
 import useQueue from '../../hooks/useQueue';
 import { Locale } from '../../store/locale';
-import { imagepath } from '../../store/imagepath';
+import { checkimage } from '../../store/imagepath';
 
 interface ItemNotificationProps {
   label: string;
@@ -29,7 +29,7 @@ const ItemNotification = React.forwardRef(
       <div
         className="item-notification-item-box"
         style={{
-          backgroundImage: `url(${`${imagepath}/${props.item.image}.png`})` || 'none',
+          backgroundImage: `url(${checkimage(props.item.image)})` || 'none',
           ...props.style,
         }}
         ref={ref}

--- a/web/src/store/imagepath.ts
+++ b/web/src/store/imagepath.ts
@@ -3,3 +3,12 @@ export let imagepath = 'images';
 export function setImagePath(path: string) {
   if (path && path !== '') imagepath = path;
 }
+
+export const checkimage = (item: any) => {
+  let image = item.name;
+  if(item.metadata?.image){
+    image = item.metadata.image;
+    if(/^https:\/\/.+(\.png|\.apng)$/.test(image)) return image;  
+  }
+  return (`${imagepath}/${image}.png`);
+}

--- a/web/src/store/imagepath.ts
+++ b/web/src/store/imagepath.ts
@@ -4,11 +4,7 @@ export function setImagePath(path: string) {
   if (path && path !== '') imagepath = path;
 }
 
-export const checkimage = (item: any) => {
-  let image = item.name;
-  if(item.metadata?.image){
-    image = item.metadata.image;
-    if(/^https:\/\/.+(\.png|\.apng)$/.test(image)) return image;  
-  }
+export const checkimage = (image: string) => {
+  if(/^https:\/\/.+(\.png|\.apng)$/.test(image)) return image;
   return (`${imagepath}/${image}.png`);
 }

--- a/web/src/store/imagepath.ts
+++ b/web/src/store/imagepath.ts
@@ -3,8 +3,3 @@ export let imagepath = 'images';
 export function setImagePath(path: string) {
   if (path && path !== '') imagepath = path;
 }
-
-export const checkimage = (image: string) => {
-  if(/^https:\/\/.+(\.png|\.apng)$/.test(image)) return image;
-  return (`${imagepath}/${image}.png`);
-}

--- a/web/src/typings/dnd.ts
+++ b/web/src/typings/dnd.ts
@@ -5,6 +5,7 @@ export type DragSource = {
   item: Pick<SlotWithItem, 'slot' | 'name'>;
   inventory: Inventory['type'];
   image?: string;
+  imageurl?: string;
 };
 
 export type DropTarget = {


### PR DESCRIPTION
This pull request introduces the ability for script creators to include images in their scripts by specifying a web-hosted URL using imgur. This feature can be useful in a variety of situations, such as allowing users to create new menu items on-demand in a business system. I have added an example to the default web development inventory to demonstrate how to use this feature, but it can be removed if desired. In addition, I have implemented the requested changes from Linden, including adding discord logs when an item with a image URL is attempted to be created, implementing a whitelist system for hosts and file types, and adding a new metadata property for the image URL. Please let me know if you have any questions or concerns about these changes.