### PR TITLE
fix (trunk/glovebox): CVehicle support of OX framework

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -555,8 +555,8 @@ local function registerCommands()
 					local checkVehicle = Vehicles.Storage[vehicleHash]
 					-- No storage or no glovebox
 					if (checkVehicle == 0 or checkVehicle == 2) or (not Vehicles.glovebox[vehicleClass] and not Vehicles.glovebox.models[vehicleHash]) then return end
-
-					local plate = GetVehicleNumberPlateText(vehicle)
+					
+					local plate = Utils.GetActualVehiclePlate(vehicle)
 					client.openInventory('glovebox', {id = 'glove'..plate, netid = NetworkGetNetworkIdFromEntity(vehicle) })
 
 					while true do
@@ -628,7 +628,7 @@ local function registerCommands()
 						local closeToVehicle = distance < 2 and open
 
 						if closeToVehicle then
-							local plate = GetVehicleNumberPlateText(vehicle)
+							local plate = Utils.GetActualVehiclePlate(vehicle)
 							TaskTurnPedToFaceCoord(playerPed, position.x, position.y, position.z, 0)
 							lastVehicle = vehicle
 							client.openInventory('trunk', {id='trunk'..plate, netid = NetworkGetNetworkIdFromEntity(vehicle)})

--- a/modules/utils/client.lua
+++ b/modules/utils/client.lua
@@ -20,6 +20,15 @@ function Utils.PlayAnimAdvanced(wait, dict, name, posX, posY, posZ, rotX, rotY, 
 	end)
 end
 
+function Utils.GetActualVehiclePlate(vehicle)
+	if shared.framework == "ox" then
+		local result = lib.callback.await("ox_inventory:getActualVehiclePlate", false, VehToNet(vehicle))
+		return result or GetVehicleNumberPlateText(vehicle)
+	end
+
+	return GetVehicleNumberPlateText(vehicle)
+end
+
 function Utils.Raycast(flag)
 	local playerCoords = GetEntityCoords(cache.ped)
 	local plyOffset = GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 2.2, -0.25)

--- a/modules/utils/server.lua
+++ b/modules/utils/server.lua
@@ -42,3 +42,8 @@ if webHook ~= '' then
 		}), headers)
 	end
 end
+
+lib.callback.register("ox_inventory:getActualVehiclePlate", function(source, netId)
+    local vehicle = Ox.GetVehicle(NetworkGetEntityFromNetworkId(netId))
+    return vehicle?.plate or nil
+end)


### PR DESCRIPTION
Getting actual vehicle plate from CVehicle object in case fake plate is installed on vehicle and also prevent from opening trunk of different vehicle if you swap a plates on vehicles.

oxcore vehicle with fake plate installed:
**CVehicle**
![image](https://user-images.githubusercontent.com/8851795/212475075-dcb99ebb-5ed5-4d9b-854c-3d77b33be63d.png)
**Plate**
![image](https://user-images.githubusercontent.com/8851795/212474851-6e94c7ca-735b-4bc9-bff1-f3b9ab2fd981.png)
**Inventory**
![image](https://user-images.githubusercontent.com/8851795/212474905-a2447e3f-857c-4af3-a95f-21a050af4db2.png)

random vehicle:
**Plate**
![image](https://user-images.githubusercontent.com/8851795/212474961-d86049f6-1ec0-4c43-bf21-b9889792e2a8.png)
**Inventory**
![image](https://user-images.githubusercontent.com/8851795/212474977-58550f09-3d5e-48f8-8143-57e9f18b3ce6.png)


