### PR TITLE
fix(weapon): weapon hash check

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1848,7 +1848,7 @@ RegisterServerEvent('ox_inventory:updateWeapon', function(action, value, slot)
 					end
 				end
 			elseif action == 'ammo' then
-				if weapon.hash == `WEAPON_FIREEXTINGUISHER` or weapon.hash == `WEAPON_PETROLCAN` then
+				if item.hash == `WEAPON_FIREEXTINGUISHER` or item.hash == `WEAPON_PETROLCAN` then
 					weapon.metadata.durability = math.floor(value)
 					weapon.metadata.ammo = weapon.metadata.durability
 				elseif value < weapon.metadata.ammo then

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1848,7 +1848,7 @@ RegisterServerEvent('ox_inventory:updateWeapon', function(action, value, slot)
 					end
 				end
 			elseif action == 'ammo' then
-				if item.hash == `WEAPON_FIREEXTINGUISHER` or item.hash == `WEAPON_PETROLCAN` then
+				if item.hash == `WEAPON_FIREEXTINGUISHER` or item.hash == `WEAPON_PETROLCAN` or item.hash == `WEAPON_HAZARDCAN` or item.hash == `WEAPON_FERTILIZERCAN` then
 					weapon.metadata.durability = math.floor(value)
 					weapon.metadata.ammo = weapon.metadata.durability
 				elseif value < weapon.metadata.ammo then


### PR DESCRIPTION
When updating ammo for durability-based weapons, the weapon hash comparison fails because `hash` property does not exist inside the `weapon` table. Hence the ammo for these weapons would not be updated.
