### PR TITLE
fakeplate integration

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -549,7 +549,7 @@ local function registerCommands()
 					-- No storage or no glovebox
 					if (checkVehicle == 0 or checkVehicle == 2) or (not Vehicles.glovebox[vehicleClass] and not Vehicles.glovebox.models[vehicleHash]) then return end
 
-					local plate = GetVehicleNumberPlateText(vehicle)
+					local plate = string.strtrim(GetVehicleNumberPlateText(vehicle))
 					client.openInventory('glovebox', {id = 'glove'..plate, netid = NetworkGetNetworkIdFromEntity(vehicle) })
 
 					while true do
@@ -621,7 +621,7 @@ local function registerCommands()
 						local closeToVehicle = distance < 2 and open
 
 						if closeToVehicle then
-							local plate = GetVehicleNumberPlateText(vehicle)
+							local plate = string.strtrim(GetVehicleNumberPlateText(vehicle))
 							TaskTurnPedToFaceCoord(playerPed, position.x, position.y, position.z, 0)
 							lastVehicle = vehicle
 							client.openInventory('trunk', {id='trunk'..plate, netid = NetworkGetNetworkIdFromEntity(vehicle)})

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -50,7 +50,7 @@ local function loadInventoryData(data, player)
 
 				for i = 1, #vehicles do
 					local vehicle = vehicles[i]
-					local plate = GetVehicleNumberPlateText(vehicle)
+					local plate = string.strtrim(GetVehicleNumberPlateText(vehicle))
 
 					if data.id:find(plate) then
 						entity = vehicle
@@ -1665,9 +1665,9 @@ local function prepareSave(inv)
 			return 1, { json.encode(minimal(inv)), inv.owner }
 		end
 	elseif inv.type == 'trunk' then
-		return 2, { json.encode(minimal(inv)), inv.dbId }
+		return 2, fakeColumn and { json.encode(minimal(inv)), inv.dbId, inv.dbId } or { json.encode(minimal(inv)), inv.dbId }
 	elseif inv.type == 'glovebox' then
-		return 3, { json.encode(minimal(inv)), inv.dbId }
+		return 3, fakeColumn and { json.encode(minimal(inv)), inv.dbId, inv.dbId } or { json.encode(minimal(inv)), inv.dbId }
 	else
 		return 4, { inv.owner or '', inv.dbId, json.encode(minimal(inv)) }
 	end

--- a/modules/mysql/server.lua
+++ b/modules/mysql/server.lua
@@ -1,13 +1,14 @@
 if not lib then return end
+fakeColumn = false
 
 local Query = {
 	SELECT_STASH = 'SELECT data FROM ox_inventory WHERE owner = ? AND name = ?',
 	UPDATE_STASH = 'INSERT INTO ox_inventory (owner, name, data) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE data = VALUES(data)',
-	SELECT_GLOVEBOX = 'SELECT plate, glovebox FROM `{vehicle_table}` WHERE `{vehicle_column}` = ?',
-	SELECT_TRUNK = 'SELECT plate, trunk FROM `{vehicle_table}` WHERE `{vehicle_column}` = ?',
+	SELECT_GLOVEBOX = 'SELECT plate, glovebox FROM `{vehicle_table}` WHERE `{vehicle_column}`',
+	SELECT_TRUNK = 'SELECT plate, trunk FROM `{vehicle_table}` WHERE `{vehicle_column}`',
 	SELECT_PLAYER = 'SELECT inventory FROM `{user_table}` WHERE `{user_column}` = ?',
-	UPDATE_TRUNK = 'UPDATE `{vehicle_table}` SET trunk = ? WHERE `{vehicle_column}` = ?',
-	UPDATE_GLOVEBOX = 'UPDATE `{vehicle_table}` SET glovebox = ? WHERE `{vehicle_column}` = ?',
+	UPDATE_TRUNK = 'UPDATE `{vehicle_table}` SET trunk = ? WHERE `{vehicle_column}`',
+	UPDATE_GLOVEBOX = 'UPDATE `{vehicle_table}` SET glovebox = ? WHERE `{vehicle_column}`',
 	UPDATE_PLAYER = 'UPDATE `{user_table}` SET inventory = ? WHERE `{user_column}` = ?',
 }
 
@@ -19,25 +20,29 @@ Citizen.CreateThreadNow(function()
 		playerColumn = 'charid'
 		vehicleTable = 'vehicles'
 		vehicleColumn = 'id'
+		fakeColumn = 'fakeplate'
 	elseif shared.framework == 'esx' then
 		playerTable = 'users'
 		playerColumn = 'identifier'
 		vehicleTable = 'owned_vehicles'
 		vehicleColumn = 'plate'
+		fakeColumn = 'fakeplate'
 	elseif shared.framework == 'qb' then
 		playerTable = 'players'
 		playerColumn = 'citizenid'
 		vehicleTable = 'player_vehicles'
 		vehicleColumn = 'plate'
+		fakeColumn = 'fakeplate'
 	elseif shared.framework == 'nd' then
 		playerTable = 'characters'
 		playerColumn = 'character_id'
 		vehicleTable = 'vehicles'
 		vehicleColumn = 'id'
+		fakeColumn = 'fakeplate'
 	end
 
 	for k, v in pairs(Query) do
-		Query[k] = v:gsub('{user_table}', playerTable):gsub('{user_column}', playerColumn):gsub('{vehicle_table}', vehicleTable):gsub('{vehicle_column}', vehicleColumn)
+		Query[k] = v:gsub('{user_table}', playerTable):gsub('{user_column}', playerColumn):gsub('{vehicle_table}', vehicleTable):gsub('`{vehicle_column}`', vehicleColumn and (fakeColumn and '`'..vehicleColumn..'` = ? OR `'..fakeColumn..'` = ?' or '`'..vehicleColumn..'` = ?') or '`'..vehicleColumn..'` = ?')
 	end
 
 	local success, result = pcall(MySQL.scalar.await, 'SELECT 1 FROM ox_inventory')
@@ -79,7 +84,7 @@ Citizen.CreateThreadNow(function()
 	result = MySQL.query.await(('SHOW COLUMNS FROM `%s`'):format(vehicleTable))
 
 	if result then
-		local glovebox, trunk
+		local glovebox, trunk, fakeplate
 
 		for i = 1, #result do
 			local column = result[i]
@@ -87,6 +92,8 @@ Citizen.CreateThreadNow(function()
 				glovebox = true
 			elseif column.Field == 'trunk' then
 				trunk = true
+			elseif column.Field == 'fakeplate' then 
+				fakeplate = true
 			end
 		end
 
@@ -96,6 +103,10 @@ Citizen.CreateThreadNow(function()
 
 		if not trunk then
 			MySQL.query(('ALTER TABLE `%s` ADD COLUMN `trunk` LONGTEXT NULL'):format(vehicleTable))
+		end
+
+		if not fakeplate then
+			MySQL.query(('ALTER TABLE `%s` ADD COLUMN `fakeplate` VARCHAR(50) DEFAULT NULL'):format(vehicleTable))
 		end
 	end
 
@@ -126,19 +137,19 @@ function db.loadStash(owner, name)
 end
 
 function db.saveGlovebox(id, inventory)
-	return MySQL.prepare(Query.UPDATE_GLOVEBOX, { inventory, id })
+	return MySQL.prepare(Query.UPDATE_GLOVEBOX, fakeColumn and { inventory,  id, id } or {inventory, id})
 end
 
 function db.loadGlovebox(id)
-	return MySQL.prepare.await(Query.SELECT_GLOVEBOX, { id })
+	return MySQL.prepare.await(Query.SELECT_GLOVEBOX, fakeColumn and { id, id } or { id })
 end
 
 function db.saveTrunk(id, inventory)
-	return MySQL.prepare(Query.UPDATE_TRUNK, { inventory, id })
+	return MySQL.prepare(Query.UPDATE_TRUNK, fakeColumn and { inventory, id, id } or { inventory, id })
 end
 
 function db.loadTrunk(id)
-	return MySQL.prepare.await(Query.SELECT_TRUNK, { id })
+	return MySQL.prepare.await(Query.SELECT_TRUNK, fakeColumn and { id, id } or { id })
 end
 
 function db.saveInventories(players, trunks, gloveboxes, stashes)


### PR DESCRIPTION
- allows for setup of fakeplate column in vehicle database. 
- checks both plate and fakeplate columns in database on trunk/glovebox inventory load to allow servers to attach fakeplates to vehicles and not lose inventory data.
- trim whitespace from beginning and end of plates less than 8 characters on inventory load. Spaces were causing issues with UpdateVehicle export
- ox/nd framework 'fakeColumn' set to 'fakeplate' but im not familiar with these 2 frameworks. can be set to false or changed if they have these fields already in their vehicle table

I made these edits purely for ESX fakeplate integration with ox_inventory. Sorry in advance if this is something unwanted