### PR TITLE
fix(client): Update distance to 3.0 to match ped target distance

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1221,7 +1221,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 							TaskTurnPedToFaceCoord(playerPed, pedCoords.x, pedCoords.y, pedCoords.z, 50)
 						end
 
-					elseif currentInventory.coords and (#(playerCoords - currentInventory.coords) > (currentInventory.distance or 2.0) or canOpenTarget(playerPed)) then
+					elseif currentInventory.coords and (#(playerCoords - currentInventory.coords) > (currentInventory.distance or 3.0) or canOpenTarget(playerPed)) then
 						client.closeInventory()
 						lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
 					end


### PR DESCRIPTION
This matches the distance in "modules/shops/client.lua" (line 70) for target distance. Otherwise it would refuse to open the inventory unless you were closer than 3 meters from the ped.

Let me know if this is incorrect, this is my first time creating a PR. 