### PR TITLE
fix(locale): Use correct locale for target inv

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1440,7 +1440,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 							if fromData.count > 0 then
 								toData.metadata = table.clone(toData.metadata)
 							end
-						else return false, 'cannot_carry' end
+						else return false, 'cannot_carry_other' end
 					end
 
 					if fromData and fromData.count < 1 then fromData = nil end


### PR DESCRIPTION
For target inventories being full, use the correct locale that it's the target inventory and not your own.