### PR TITLE
fix(modules/inventory/server): wrong maxWeight case

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2080,7 +2080,7 @@ local function registerStash(name, label, slots, maxWeight, owner, groups, coord
 	name, slots, maxWeight, coords = checkStashProperties({
 		name = name,
 		slots = slots,
-		maxweight = maxWeight,
+		maxWeight = maxWeight,
 		coords = coords,
 	})
 


### PR DESCRIPTION
Was causing this issue:
![image](https://user-images.githubusercontent.com/47056777/218313408-7f6482aa-830e-4405-a281-93c0bd418f35.png)
