### PR TITLE
fix(server/inventory): error clearing an already empty inventory

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1678,7 +1678,7 @@ exports('ReturnInventory', Inventory.Return)
 function Inventory.Clear(inv, keep)
 	inv = Inventory(inv) --[[@as OxInventory]]
 	if not inv then return end
-
+    if not next(inv.items) then inv.items = {} return end
 	local updateSlots = inv.player and {}
 	local newWeight = 0
 	local inc = 0


### PR DESCRIPTION
Fixing an issue which throws an error on the console when trying to empty an already cleaned inventory.