### PR TITLE
feat(server): Show Metadata label in Progressbar

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -237,7 +237,7 @@ lib.callback.register('ox_inventory:useItem', function(source, itemName, slot, m
 		end
 
 		if item and data and data.count > 0 and data.name == item.name then
-			data = {name=data.name, label=data.label, count=data.count, slot=slot, metadata=data.metadata}
+			data = {name=data.name, label=data.metadata?.label or data.label, count=data.count, slot=slot, metadata=data.metadata}
 
 			if item.weapon then
 				inventory.weapon = inventory.weapon ~= slot and slot or nil


### PR DESCRIPTION
im not sure if title is correct, the change is on server but the effect is on client.

when using the item with usetime, 
this will show Metadata Label instead of the Items Data (items.lua) label if item have metadata.label value.