### PR TITLE
fix(client): disable rolling while reloading

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -495,6 +495,13 @@ local function useSlot(slot)
 						AddAmmoToPed(playerPed, currentWeapon.hash, addAmmo)
 						Wait(100)
 						MakePedReload(playerPed)
+							
+						SetTimeout(100, function()
+							while IsPedReloading(playerPed) do
+								DisableControlAction(0, 22, true)
+								Wait(0)
+							end
+						end)
 					end
 
 					currentWeapon.metadata.ammo = newAmmo


### PR DESCRIPTION
With some weapons if you roll while reloading it let's you reload faster (e.g. WEAPON_MUSKET) or cause weapon to bug and don't let you to shoot with it (e.g. WEAPON_MINISMG, WEAPON_MACHINEPISTOL).