### PR TITLE
feat(shops/server): item metadata weight

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1629,7 +1629,7 @@ lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
 	recipe = CraftingBenches[id].items[recipe]
 
 	return lib.progressCircle({
-		label = locale('crafting_item', Items[recipe.name].label),
+		label = locale('crafting_item', recipe.metadata?.label or Items[recipe.name].label),
 		duration = recipe.duration or 3000,
 		canCancel = true,
 		disable = {

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -41,7 +41,7 @@ local function setupShopItems(id, shopType, shopName, groups)
 			slot = {
 				name = Item.name,
 				slot = i,
-				weight = Item.weight,
+				weight = slot.metadata?.weight or Item.weight,
 				count = slot.count,
 				price = (server.randomprices and not slot.currency or slot.currency == 'money') and (math.ceil(slot.price * (math.random(80, 120)/100))) or slot.price or 0,
 				metadata = slot.metadata,


### PR DESCRIPTION
When using metadata for weight in shops for example the clothing item, it now shows the correct weight in the shop instead of in your inventory after purchase.