### PR TITLE
Fix image url being broken

### DIFF
--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -3,7 +3,8 @@ if not lib then return end
 ---@overload fun(name: string): OxServerItem
 local Items = {}
 local ItemList = require 'modules.items.shared' --[[@as { [string]: OxServerItem }]]
-
+local Utils = require 'modules.utils.server'
+ 
 TriggerEvent('ox_inventory:itemList', ItemList)
 
 Items.containers = require 'modules.items.containers'

--- a/modules/utils/server.lua
+++ b/modules/utils/server.lua
@@ -1,4 +1,6 @@
-Utils = {}
+if not lib then return end
+
+local Utils = {}
 
 local webHook = GetConvar('inventory:webhook', '')
 
@@ -42,3 +44,5 @@ if webHook ~= '' then
 		}), headers)
 	end
 end
+
+return Utils


### PR DESCRIPTION
Recently updated to latest and image url seems to be broken due to Utils no longer being loaded, so I updated server utils to follow the same scheme as the client Utils, I tested and this fixed the issue.

Issue PNG
https://i.gyazo.com/87efcac2cb5348ab7c720822502e16be.png