### PR TITLE
fix(module/shops): check for the latest occurrence of space

### DIFF
--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -191,7 +191,7 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 	if data.toType == 'player' then
 		if data.count == nil then data.count = 1 end
 		local playerInv = Inventory(source)
-		local shopType, shopId = playerInv.open:match("^(.-)%s+(%S+)$")
+		local shopType, shopId = playerInv.open:match("^(.-)%s-(%d-)$")
 
 		if not shopType then shopType = playerInv.open end
 		if shopId then shopId = tonumber(shopId) end

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -191,8 +191,9 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 	if data.toType == 'player' then
 		if data.count == nil then data.count = 1 end
 		local playerInv = Inventory(source)
-		local shopType, shopId = string.strsplit(' ', playerInv.open)
+		local shopType, shopId = playerInv.open:match("^(.-)%s+(%S+)$")
 
+		if not shopType then shopType = playerInv.open end
 		if shopId then shopId = tonumber(shopId) end
 
 		local shop = shopId and Shops[shopType][shopId] or Shops[shopType]


### PR DESCRIPTION
This fixes the error that is thrown in case `playerInv.open` has more than 1 space occurrence in its string value.
Previously, when the `playerInv.open` value was something like "Cat Cafe Shop 1", the `shopType` would have been "Cat" instead of "Cat Cafe Shop".

Also tested it with global shops so no such https://github.com/overextended/ox_inventory/issues/1146 issue would happen.