### PR TITLE
Fix(modules/Hooks): Fix shop inventory being nil

### DIFF
--- a/modules/hooks/server.lua
+++ b/modules/hooks/server.lua
@@ -35,7 +35,7 @@ local function TriggerEventHooks(event, payload)
     local hooks = eventHooks[event]
 
     if hooks then
-		local fromInventory = payload.fromInventory and tostring(payload.fromInventory) or payload.inventoryId and tostring(payload.inventoryId)
+		local fromInventory = payload.fromInventory and tostring(payload.fromInventory) or payload.inventoryId and tostring(payload.inventoryId) or payload.shopType and tostring(payload.shopType)
 		local toInventory = payload.toInventory and tostring(payload.toInventory)
 
         for i = 1, #hooks do


### PR DESCRIPTION
I found an issue with fromInventory being nil when using inventory filter for shops.

Prints being nil
![image](https://user-images.githubusercontent.com/34508112/230802831-ae16c651-f12d-49fd-918b-c95c22e41872.png)

Console error
![image](https://user-images.githubusercontent.com/34508112/230802823-0c8921cd-972c-4aae-ac46-e3d11f676a75.png)

After fix
![image](https://user-images.githubusercontent.com/34508112/230802813-d61a14cc-7806-4d9a-8b2c-4c747ceb2a22.png)
