### PR TITLE
Multi-access inventories / inventory-sync

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1715,7 +1715,19 @@ RegisterNUICallback('buyItem', function(data, cb)
 			}
 		}, data[4])
 
-		SendNUIMessage({ action = 'refreshSlots', data = data[3] and {items = {{item = data[2]}, {item = data[3], inventory = 'shop'}}} or {items = {item = data[2]}}})
+		if data[3] then
+			SendNUIMessage({
+				action = 'refreshSlots',
+				data = {
+					items = {
+						{
+							item = data[3],
+							inventory = 'shop'
+						}
+					}
+				}
+			})
+		end
 	end
 
 	if message then

--- a/client.lua
+++ b/client.lua
@@ -853,20 +853,23 @@ local function updateInventory(items, weight)
 		client.setPlayerData('weight', weight)
 	else
 		for i = 1, #items do
-			local v = items[i].item
-			local item = PlayerData.inventory[v.slot]
+			if items[i].inventory == cache.serverId then
+				items[i].inventory = 'player'
+				local v = items[i].item
+				local item = PlayerData.inventory[v.slot]
 
-			if item?.name then
-				itemCount[item.name] = (itemCount[item.name] or 0) - item.count
+				if item?.name then
+					itemCount[item.name] = (itemCount[item.name] or 0) - item.count
+				end
+
+				if v.count then
+					itemCount[v.name] = (itemCount[v.name] or 0) + v.count
+				end
+
+				changes[v.slot] = v.count and v or false
+				if not v.count then v.name = nil end
+				PlayerData.inventory[v.slot] = v.name and v or nil
 			end
-
-			if v.count then
-				itemCount[v.name] = (itemCount[v.name] or 0) + v.count
-			end
-
-			changes[v.slot] = v.count and v or false
-			if not v.count then v.name = nil end
-			PlayerData.inventory[v.slot] = v.name and v or nil
 		end
 
 		SendNUIMessage({ action = 'refreshSlots', data = { items = items, itemCount = itemCount} })
@@ -912,7 +915,7 @@ local function updateInventory(items, weight)
 	TriggerEvent('ox_inventory:updateInventory', changes)
 end
 
-RegisterNetEvent('ox_inventory:updateSlots', function(items, weights, count, removed)
+RegisterNetEvent('ox_inventory:updateSlots', function(items, weights)
 	if source == '' or not next(items) then return end
 
 	local item = items[1]?.item
@@ -926,13 +929,13 @@ RegisterNetEvent('ox_inventory:updateSlots', function(items, weights, count, rem
 		TriggerEvent('ox_inventory:currentWeapon', currentWeapon)
 	end
 
-	if count then
-		if not item.name then
-			item = PlayerData.inventory[item.slot]
-		end
+	-- if count then
+	-- 	if not item.name then
+	-- 		item = PlayerData.inventory[item.slot]
+	-- 	end
 
-		Utils.ItemNotify({ item, removed and 'ui_removed' or 'ui_added', count })
-	end
+	-- 	Utils.ItemNotify({ item, removed and 'ui_removed' or 'ui_added', count })
+	-- end
 
 	updateInventory(items, weights)
 end)

--- a/client.lua
+++ b/client.lua
@@ -857,13 +857,22 @@ local function updateInventory(items, weight)
 				items[i].inventory = 'player'
 				local v = items[i].item
 				local item = PlayerData.inventory[v.slot]
+				local count = 0
 
 				if item?.name then
+					count -= item.count
 					itemCount[item.name] = (itemCount[item.name] or 0) - item.count
 				end
 
 				if v.count then
+					count += v.count
 					itemCount[v.name] = (itemCount[v.name] or 0) + v.count
+				end
+
+				if count < 1 then
+					Utils.ItemNotify({ item?.name and item or v, 'ui_removed', -count })
+				else
+					Utils.ItemNotify({ v, 'ui_added', count })
 				end
 
 				changes[v.slot] = v.count and v or false
@@ -928,14 +937,6 @@ RegisterNetEvent('ox_inventory:updateSlots', function(items, weights)
 		currentWeapon.metadata = item.metadata
 		TriggerEvent('ox_inventory:currentWeapon', currentWeapon)
 	end
-
-	-- if count then
-	-- 	if not item.name then
-	-- 		item = PlayerData.inventory[item.slot]
-	-- 	end
-
-	-- 	Utils.ItemNotify({ item, removed and 'ui_removed' or 'ui_added', count })
-	-- end
 
 	updateInventory(items, weights)
 end)

--- a/client.lua
+++ b/client.lua
@@ -72,6 +72,7 @@ local defaultInventory = {
 	maxWeight = shared.playerweight,
 	items = {}
 }
+
 local currentInventory = defaultInventory
 
 local function closeTrunk()
@@ -828,6 +829,8 @@ end
 
 RegisterNetEvent('ox_inventory:closeInventory', client.closeInventory)
 
+---@param items updateSlot[]
+---@param weight number | table<string, number>
 local function updateInventory(items, weight)
 	-- todo: combine iterators
 	local changes = {}
@@ -1701,10 +1704,17 @@ RegisterNUICallback('swapItems', function(data, cb)
 end)
 
 RegisterNUICallback('buyItem', function(data, cb)
+	---@type boolean, false | { [1]: number, [2]: SlotWithItem, [3]: SlotWithItem | false, [4]: number}, NotifyProps
 	local response, data, message = lib.callback.await('ox_inventory:buyItem', 100, data)
 
 	if data then
-		updateInventory({ item = data[2], inventory = cache.serverId }, data[4])
+		updateInventory({
+			{
+				item = data[2],
+				inventory = cache.serverId
+			}
+		}, data[4])
+
 		SendNUIMessage({ action = 'refreshSlots', data = data[3] and {items = {{item = data[2]}, {item = data[3], inventory = 'shop'}}} or {items = {item = data[2]}}})
 	end
 

--- a/client.lua
+++ b/client.lua
@@ -610,7 +610,7 @@ local function registerCommands()
 				return client.closeInventory()
 			end
 
-			local closest = lib.points.closest()
+			local closest = lib.points.getClosestPoint()
 
 			if closest and closest.currentDistance < 1.2 and (not closest.instance or closest.instance == currentInstance) then
 				if closest.inv == 'crafting' then

--- a/client.lua
+++ b/client.lua
@@ -934,7 +934,7 @@ RegisterNetEvent('ox_inventory:inventoryReturned', function(data)
 
 	for _, slotData in pairs(data[1]) do
 		num += 1
-		items[num] = { item = slotData, inventory = 'player' }
+		items[num] = { item = slotData, inventory = cache.serverId }
 	end
 
 	updateInventory(items, { left = data[3] })
@@ -951,7 +951,7 @@ RegisterNetEvent('ox_inventory:inventoryConfiscated', function(message)
 
 	for slot in pairs(PlayerData.inventory) do
 		num += 1
-		items[num] = { item = { slot = slot }, inventory = 'player' }
+		items[num] = { item = { slot = slot }, inventory = cache.serverId }
 	end
 
 	updateInventory(items, { left = 0 })
@@ -1682,8 +1682,6 @@ RegisterNUICallback('swapItems', function(data, cb)
 		end
 	end
 
-	cb(false)
-
 	local success, response, weaponSlot = lib.callback.await('ox_inventory:swapItems', false, data)
 
 	if success then
@@ -1699,18 +1697,14 @@ RegisterNUICallback('swapItems', function(data, cb)
 		lib.notify({ type = 'error', description = locale(response) })
 	end
 
-	if data.toType == 'newdrop' then
-		Wait(50)
-	end
-
-	-- cb(success or false)
+	cb(success or false)
 end)
 
 RegisterNUICallback('buyItem', function(data, cb)
 	local response, data, message = lib.callback.await('ox_inventory:buyItem', 100, data)
 
 	if data then
-		updateInventory({[data[1]] = data[2]}, data[4])
+		updateInventory({ item = data[2], inventory = cache.serverId }, data[4])
 		SendNUIMessage({ action = 'refreshSlots', data = data[3] and {items = {{item = data[2]}, {item = data[3], inventory = 'shop'}}} or {items = {item = data[2]}}})
 	end
 

--- a/client.lua
+++ b/client.lua
@@ -832,59 +832,41 @@ local function updateInventory(items, weight)
 	-- todo: combine iterators
 	local changes = {}
 	local itemCount = {}
-	-- swapslots
-	if type(weight) == 'number' then
-		for slot, v in pairs(items) do
-			local item = PlayerData.inventory[slot]
+	local isSwapSlot = type(weight) == 'number'
 
-			if item then
+	for i = 1, #items do
+		if items[i].inventory == cache.serverId then
+			items[i].inventory = 'player'
+			local v = items[i].item
+			local item = PlayerData.inventory[v.slot]
+			local count = 0
+
+			if item?.name then
+				count -= item.count
 				itemCount[item.name] = (itemCount[item.name] or 0) - item.count
 			end
 
-			if v then
+			if v.count then
+				count += v.count
 				itemCount[v.name] = (itemCount[v.name] or 0) + v.count
 			end
 
-			PlayerData.inventory[slot] = v and v or nil
-			changes[slot] = v
-		end
-
-		SendNUIMessage({ action = 'refreshSlots', data = {itemCount = itemCount} })
-		client.setPlayerData('weight', weight)
-	else
-		for i = 1, #items do
-			if items[i].inventory == cache.serverId then
-				items[i].inventory = 'player'
-				local v = items[i].item
-				local item = PlayerData.inventory[v.slot]
-				local count = 0
-
-				if item?.name then
-					count -= item.count
-					itemCount[item.name] = (itemCount[item.name] or 0) - item.count
-				end
-
-				if v.count then
-					count += v.count
-					itemCount[v.name] = (itemCount[v.name] or 0) + v.count
-				end
-
+			if not isSwapSlot then
 				if count < 1 then
 					Utils.ItemNotify({ item?.name and item or v, 'ui_removed', -count })
 				else
 					Utils.ItemNotify({ v, 'ui_added', count })
 				end
-
-				changes[v.slot] = v.count and v or false
-				if not v.count then v.name = nil end
-				PlayerData.inventory[v.slot] = v.name and v or nil
 			end
-		end
 
-		SendNUIMessage({ action = 'refreshSlots', data = { items = items, itemCount = itemCount} })
-		client.setPlayerData('weight', weight.left)
+			changes[v.slot] = v.count and v or false
+			if not v.count then v.name = nil end
+			PlayerData.inventory[v.slot] = v.name and v or nil
+		end
 	end
 
+	SendNUIMessage({ action = 'refreshSlots', data = { items = items, itemCount = itemCount} })
+	client.setPlayerData('weight', isSwapSlot and weight or weight.left)
 
 	for item, count in pairs(itemCount) do
 		local data = Items[item]
@@ -1700,6 +1682,8 @@ RegisterNUICallback('swapItems', function(data, cb)
 		end
 	end
 
+	cb(false)
+
 	local success, response, weaponSlot = lib.callback.await('ox_inventory:swapItems', false, data)
 
 	if success then
@@ -1719,7 +1703,7 @@ RegisterNUICallback('swapItems', function(data, cb)
 		Wait(50)
 	end
 
-	cb(success or false)
+	-- cb(success or false)
 end)
 
 RegisterNUICallback('buyItem', function(data, cb)

--- a/modules/bridge/server.lua
+++ b/modules/bridge/server.lua
@@ -47,17 +47,13 @@ local function playerDropped(source)
 	local inv = Inventory(source)
 
 	if inv?.player then
-		local openInventory = inv.open and Inventory(inv.open)
-
-		if openInventory then
-			openInventory:set('open', false)
-		end
+		Inventory.Close(inv)
 
 		if shared.framework ~= 'esx' then
 			db.savePlayer(inv.owner, json.encode(inv:minimal()))
 		end
 
-		Inventory.Remove(inv)
+		Inventory.Remove(inv, true)
 	end
 end
 

--- a/modules/bridge/server.lua
+++ b/modules/bridge/server.lua
@@ -44,10 +44,10 @@ CreateThread(function()
 end)
 
 local function playerDropped(source)
-	local inv = Inventory(source)
+	local inv = Inventory(source) --[[@as OxInventory]]
 
 	if inv?.player then
-		Inventory.Close(inv)
+		inv:closeInventory()
 
 		if shared.framework ~= 'esx' then
 			db.savePlayer(inv.owner, json.encode(inv:minimal()))

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -62,16 +62,12 @@ lib.callback.register('ox_inventory:openCraftingBench', function(source, id, ind
 			local inv = Inventory(left.open)
 
 			-- Why would the player inventory open with an invalid target? Can't repro but whatever.
-			if inv then
-				if inv.player then
-					TriggerClientEvent('ox_inventory:closeInventory', inv.id, true)
-				end
-
-				inv:set('open', false)
+			if inv?.player then
+				Inventory.Close(inv)
 			end
 		end
 
-		left.open = source
+		Inventory.Open(left, left)
 	end
 
 	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -59,15 +59,15 @@ lib.callback.register('ox_inventory:openCraftingBench', function(source, id, ind
 		if #(GetEntityCoords(GetPlayerPed(source)) - coords) > 10 then return end
 
 		if left.open and left.open ~= source then
-			local inv = Inventory(left.open)
+			local inv = Inventory(left.open) --[[@as OxInventory]]
 
 			-- Why would the player inventory open with an invalid target? Can't repro but whatever.
 			if inv?.player then
-				Inventory.Close(inv)
+				inv:closeInventory()
 			end
 		end
 
-		Inventory.Open(left, left)
+		left:openInventory(left)
 	end
 
 	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }
@@ -194,7 +194,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 									newItem.metadata.durability = durability < 0 and 0 or durability
 									durability = 0
 
-									TriggerClientEvent('ox_inventory:updateSlots', left.id, {
+									left:syncSlotsWithPlayer({
 										{
 											item = newItem,
 											inventory = left.type
@@ -208,7 +208,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 							invSlot.metadata.durability = durability < 0 and 0 or durability
 						end
 
-						TriggerClientEvent('ox_inventory:updateSlots', source, {
+						left:syncSlotsWithPlayer({
 							{
 								item = invSlot,
 								inventory = left.type

--- a/modules/init.lua
+++ b/modules/init.lua
@@ -163,7 +163,7 @@ local success, msg = lib.checkDependency('oxmysql', '2.4.0')
 
 if not success then return spamError(msg) end
 
-success, msg = lib.checkDependency('ox_lib', '3.0.0')
+success, msg = lib.checkDependency('ox_lib', '3.2.0')
 
 if not success then spamError(msg) end
 

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1464,7 +1464,6 @@ local function dropItem(source, data)
 
 	playerInventory.weight -= toData.weight
 	local slot = data.fromSlot
-	local items = { [slot] = fromData or false }
 	playerInventory.items[slot] = fromData
 
 	if slot == playerInventory.weapon then
@@ -1485,7 +1484,15 @@ local function dropItem(source, data)
 
 	if server.syncInventory then server.syncInventory(playerInventory) end
 
-	return true, { weight = playerInventory.weight, items = items }
+	return true, {
+		weight = playerInventory.weight,
+		items = {
+			{
+				item = fromData or { slot = data.fromSlot },
+				inventory = playerInventory.id
+			}
+		}
+	}
 end
 
 local activeSlots = {}

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -66,6 +66,7 @@ function OxInventory:closeInventory(noEvent)
 	inv.openedBy[self.id] = nil
 	self.open = false
 	self.currentShop = nil
+	self.containerSlot = nil
 
 	if not noEvent then
 		TriggerClientEvent('ox_inventory:closeInventory', self.id, true)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -44,8 +44,6 @@ function OxInventory:openInventory(inv)
 
 	if not inv or not self then return end
 
-	print(('opened playerinv-%s and inv-%s'):format(self.id, inv.id))
-
 	inv:set('open', true)
 	inv.openedBy[self.id] = true
 	self.open = inv.id
@@ -59,8 +57,6 @@ function OxInventory:closeInventory(noEvent)
 	local inv = self.open and Inventory(self.open)
 
 	if not inv then return end
-
-	print(('closed playerinv-%s and inv-%s'):format(self.id, inv.id))
 
 	inv:set('open', false)
 	inv.openedBy[self.id] = nil
@@ -1538,7 +1534,6 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 			local _ <close> = defer(function()
 				activeSlots[fromRef] = nil
 				activeSlots[toRef] = nil
-				print('cleared', fromRef, toRef)
 			end)
 
 			local sameInventory = fromInventory.id == toInventory.id

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1570,14 +1570,6 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 									Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight, playerInventory)
 								end
 
-								if fromOtherPlayer then
-									TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id, { fromData, 'ui_removed', fromData.count })
-									TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id, { toData, 'ui_added', toData.count })
-								elseif toOtherPlayer then
-									TriggerClientEvent('ox_inventory:itemNotify', toInventory.id, { fromData, 'ui_added', fromData.count })
-									TriggerClientEvent('ox_inventory:itemNotify', toInventory.id, { toData, 'ui_removed', toData.count })
-								end
-
 								toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot) --[[@as table]]
 
 								if server.loglevel > 0 then
@@ -1615,12 +1607,6 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 								if container then
 									Inventory.ContainerWeight(containerItem, toInventory.type == 'container' and toInventory.weight or fromInventory.weight, playerInventory)
-								end
-
-								if fromOtherPlayer then
-									TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id, { fromData, 'ui_removed', data.count })
-								elseif toOtherPlayer then
-									TriggerClientEvent('ox_inventory:itemNotify', toInventory.id, { toData, 'ui_added', data.count })
 								end
 
 								if server.loglevel > 0 then
@@ -1665,12 +1651,6 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 								if container then
 									Inventory.ContainerWeight(containerItem, toContainer and toInventory.weight or fromInventory.weight, playerInventory)
-								end
-
-								if fromOtherPlayer then
-									TriggerClientEvent('ox_inventory:itemNotify', fromInventory.id, { fromData, 'ui_removed', data.count })
-								elseif toOtherPlayer then
-									TriggerClientEvent('ox_inventory:itemNotify', toInventory.id, { fromData, 'ui_added', data.count })
 								end
 
 								if server.loglevel > 0 then

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1516,9 +1516,11 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 			local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
 			local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
 
-			while activeSlots[fromRef] or activeSlots[toRef] do
-				Wait(0)
-			end
+			-- while activeSlots[fromRef] or activeSlots[toRef] do
+			-- 	Wait(0)
+			-- end
+
+			if activeSlots[fromRef] or activeSlots[toRef] then return false end
 
 			activeSlots[fromRef] = true
 			activeSlots[toRef] = true

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1710,32 +1710,30 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					if toInventory.changed ~= nil then toInventory.changed = true end
 
 					if sameInventory then
-						if not fromOtherPlayer then
-							fromInventory:syncSlotsWithClients({
-								{
-									item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
-									inventory = fromInventory.id
-								},
-								{
-									item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
-									inventory = fromInventory.id
-								}
-							}, { left = fromInventory.weight }, true)
-						end
-					elseif toInventory.id ~= playerInventory.id then
+						fromInventory:syncSlotsWithClients({
+							{
+								item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
+								inventory = fromInventory.id
+							},
+							{
+								item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
+								inventory = fromInventory.id
+							}
+						}, { left = fromInventory.weight })
+					else
 						toInventory:syncSlotsWithClients({
 							{
 								item = toInventory.items[data.toSlot] or { slot = data.toSlot },
 								inventory = toInventory.id
 							}
-						}, { left = toInventory.weight }, true)
-					elseif fromInventory.id ~= playerInventory.id then
+						}, { left = toInventory.weight })
+
 						fromInventory:syncSlotsWithClients({
 							{
 								item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
 								inventory = fromInventory.id
 							}
-						}, { left = fromInventory.weight }, true)
+						}, { left = fromInventory.weight })
 					end
 
 					local resp

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -11,7 +11,7 @@ local Inventory = {}
 ---@field weight number
 ---@field maxWeight number
 ---@field open? number|false
----@field items table<number, OxServerItem?>
+---@field items table<number, SlotWithItem?>
 ---@field set function
 ---@field get function
 ---@field minimal function
@@ -73,7 +73,7 @@ function OxInventory:closeInventory(noEvent)
 	end
 end
 
----@alias updateSlot { item: OxServerItem | { slot: number }, inventory: string }
+---@alias updateSlot { item: SlotWithItem | { slot: number }, inventory: string|number }
 
 ---Sync a player's inventory state.
 ---@param slots updateSlot[]
@@ -904,7 +904,7 @@ local Utils = require 'modules.utils.server'
 
 ---@param inv inventory
 ---@param slot number | false
----@param metadata table
+---@param metadata { [string]: any }
 function Inventory.SetMetadata(inv, slot, metadata)
 	inv = Inventory(inv) --[[@as OxInventory]]
 	local slotData = inv and type(slot) == 'number' and inv.items[slot]
@@ -983,8 +983,8 @@ exports('SetMaxWeight', Inventory.SetMaxWeight)
 ---@param count number
 ---@param metadata? table | string
 ---@param slot? number
----@param cb? fun(success?: boolean, response: string|OxItem|nil)
----@return boolean? success, string|OxItem|nil response
+---@param cb? fun(success?: boolean, response: string|SlotWithItem|nil)
+---@return boolean? success, string|SlotWithItem|nil response
 function Inventory.AddItem(inv, item, count, metadata, slot, cb)
 	if type(item) ~= 'table' then item = Items(item) end
 
@@ -1372,7 +1372,7 @@ exports('CanSwapItem', Inventory.CanSwapItem)
 ---Mostly for internal use, but deprecated.
 ---@param name string
 ---@param count number
----@param metadata table
+---@param metadata { [string]: any }
 ---@param slot number
 RegisterServerEvent('ox_inventory:removeItem', function(name, count, metadata, slot)
 	Inventory.RemoveItem(source, name, count, metadata, slot)
@@ -1712,7 +1712,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 							inventory = fromInventory.id
 						}
 
-						if toInventory.type == 'container' then
+						if toInventory.type == 'container' and containerItem then
 							items[#items + 1] = {
 								item = containerItem,
 								inventory = playerInventory.id
@@ -1726,7 +1726,7 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 							inventory = toInventory.id
 						}
 
-						if fromInventory.type == 'container' then
+						if fromInventory.type == 'container' and containerItem then
 							items[#items + 1] = {
 								item = containerItem,
 								inventory = playerInventory.id

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1549,8 +1549,12 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 				if fromData and (not fromData.metadata.container or fromData.metadata.container and toInventory.type ~= 'container') then
 					if data.count > fromData.count then data.count = fromData.count end
 
-					local container = (not sameInventory and playerInventory.containerSlot) and (fromInventory.type == 'container' and fromInventory or toInventory)
-					local containerItem = container and playerInventory.items[playerInventory.containerSlot]
+					local container, containerItem = (not sameInventory and playerInventory.containerSlot) and (fromInventory.type == 'container' and fromInventory or toInventory)
+
+					if container then
+						containerItem = playerInventory.items[playerInventory.containerSlot]
+					end
+
 					local hookPayload = {
 						source = source,
 						fromInventory = fromInventory.id,
@@ -1687,19 +1691,34 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 
 					if fromData and fromData.count < 1 then fromData = nil end
 
+					---@type updateSlot[]
 					local items = {}
 
 					if fromInventory.player and not fromOtherPlayer then
-						items[data.fromSlot] = fromData or false
+						items[#items + 1] = {
+							item = fromData or { slot = data.fromSlot },
+							inventory = fromInventory.id
+						}
+
 						if toInventory.type == 'container' then
-							items[playerInventory.containerSlot] = containerItem
+							items[#items + 1] = {
+								item = containerItem,
+								inventory = playerInventory.id
+							}
 						end
 					end
 
 					if toInventory.player and not toOtherPlayer then
-						items[data.toSlot] = toData or false
+						items[#items + 1] = {
+							item = toData or { slot = data.toSlot },
+							inventory = toInventory.id
+						}
+
 						if fromInventory.type == 'container' then
-							items[playerInventory.containerSlot] = containerItem
+							items[#items + 1] = {
+								item = containerItem,
+								inventory = playerInventory.id
+							}
 						end
 					end
 

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1637,33 +1637,46 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					if fromInventory.changed ~= nil then fromInventory.changed = true end
 					if toInventory.changed ~= nil then toInventory.changed = true end
 
-					if sameInventory and fromOtherPlayer then
-						TriggerClientEvent('ox_inventory:updateSlots', fromInventory.id,{
-							{
-								item = fromInventory.items[data.toSlot] or {slot=data.toSlot},
-								inventory = fromInventory.type
-							},
-							{
-								item = fromInventory.items[data.fromSlot] or {slot=data.fromSlot},
-								inventory = fromInventory.type
-							}
-						}, { left = fromInventory.weight })
-
-					elseif toOtherPlayer then
-						TriggerClientEvent('ox_inventory:updateSlots', toInventory.id,{
-							{
-								item = toInventory.items[data.toSlot] or {slot=data.toSlot},
-								inventory = toInventory.type
-							}
-						}, { left = toInventory.weight })
-
-					elseif fromOtherPlayer then
-						TriggerClientEvent('ox_inventory:updateSlots', fromInventory.id,{
-							{
-								item = fromInventory.items[data.fromSlot] or {slot=data.fromSlot},
-								inventory = fromInventory.type
-							}
-						}, { left = fromInventory.weight })
+					if sameInventory then
+						for pId in pairs(fromInventory.openedBy) do
+							if source ~= pId then
+								print('sync player-'..pId..' with "sameInventory" '..fromInventory.id)
+								TriggerClientEvent('ox_inventory:updateSlots', pId, {
+									{
+										item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
+										inventory = fromInventory.type
+									},
+									{
+										item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
+										inventory = fromInventory.type
+									}
+								}, { left = fromInventory.weight })
+							end
+						end
+					elseif toInventory.id ~= playerInventory.id then
+						for pId in pairs(toInventory.openedBy) do
+							if source ~= pId then
+								print('sync player-'..pId..' with "toInventory" '..toInventory.id)
+								TriggerClientEvent('ox_inventory:updateSlots', pId, {
+									{
+										item = toInventory.items[data.toSlot] or { slot = data.toSlot },
+										inventory = toInventory.type
+									}
+								}, { left = toInventory.weight })
+							end
+						end
+					elseif fromInventory.id ~= playerInventory.id then
+						for pId in pairs(fromInventory.openedBy) do
+							if source ~= pId then
+								print('sync player-'..pId..' with "fromInventory" '..fromInventory.id)
+								TriggerClientEvent('ox_inventory:updateSlots', pId, {
+									{
+										item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
+										inventory = fromInventory.type
+									}
+								}, { left = fromInventory.weight })
+							end
+						end
 					end
 
 					local resp

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1712,30 +1712,32 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					if toInventory.changed ~= nil then toInventory.changed = true end
 
 					if sameInventory then
-						fromInventory:syncSlotsWithClients({
-							{
-								item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
-								inventory = fromInventory.id
-							},
-							{
-								item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
-								inventory = fromInventory.id
-							}
-						}, { left = fromInventory.weight })
+						if not fromOtherPlayer then
+							fromInventory:syncSlotsWithClients({
+								{
+									item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
+									inventory = fromInventory.id
+								},
+								{
+									item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
+									inventory = fromInventory.id
+								}
+							}, { left = fromInventory.weight }, true)
+						end
 					elseif toInventory.id ~= playerInventory.id then
 						toInventory:syncSlotsWithClients({
 							{
 								item = toInventory.items[data.toSlot] or { slot = data.toSlot },
 								inventory = toInventory.id
 							}
-						}, { left = toInventory.weight })
+						}, { left = toInventory.weight }, true)
 					elseif fromInventory.id ~= playerInventory.id then
 						fromInventory:syncSlotsWithClients({
 							{
 								item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
 								inventory = fromInventory.id
 							}
-						}, { left = fromInventory.weight })
+						}, { left = fromInventory.weight }, true)
 					end
 
 					local resp

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1488,6 +1488,8 @@ local function dropItem(source, data)
 	return true, { weight = playerInventory.weight, items = items }
 end
 
+local activeSlots = {}
+
 lib.callback.register('ox_inventory:swapItems', function(source, data)
 	if data.count > 0 and data.toType ~= 'shop' then
 		if data.toType == 'newdrop' then
@@ -1510,6 +1512,22 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 			end
 
 			if not toInventory then return end
+
+			local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
+			local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
+
+			while activeSlots[fromRef] or activeSlots[toRef] do
+				Wait(0)
+			end
+
+			activeSlots[fromRef] = true
+			activeSlots[toRef] = true
+
+			local _ <close> = defer(function()
+				activeSlots[fromRef] = nil
+				activeSlots[toRef] = nil
+				print('cleared', fromRef, toRef)
+			end)
 
 			local sameInventory = fromInventory.id == toInventory.id
 			local fromOtherPlayer = fromInventory.player and fromInventory ~= playerInventory

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -269,7 +269,9 @@ exports('GetInventoryItems', function(inv, owner)
 	return getInventory(inv, owner)?.items
 end)
 
-function Inventory.CloseAll(inv)
+---@param inv? inventory
+---@param ignoreId? number
+function Inventory.CloseAll(inv, ignoreId)
 	if not inv then
 		for _, data in pairs(Inventories) do
 			for playerId in pairs(data.openedBy) do
@@ -282,14 +284,14 @@ function Inventory.CloseAll(inv)
 		return TriggerClientEvent('ox_inventory:closeInventory', -1, true)
 	end
 
-	inv = Inventory(inv)
+	inv = Inventory(inv) --[[@as OxInventory?]]
 
 	if not inv then return end
 
 	for playerId in pairs(inv.openedBy) do
 		local playerInv = Inventory(playerId)
 
-		if playerInv then playerInv:closeInventory() end
+		if playerInv and (not ignoreId or playerId ~= ignoreId) then playerInv:closeInventory() end
 	end
 end
 

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1497,312 +1497,312 @@ end
 local activeSlots = {}
 
 lib.callback.register('ox_inventory:swapItems', function(source, data)
-	if data.count > 0 and data.toType ~= 'shop' then
-		if data.toType == 'newdrop' then
-			return dropItem(source, data)
-		else
-			local playerInventory = Inventory(source)
+	if data.count < 1 then return end
 
-			if not playerInventory then return end
+	if data.toType == 'newdrop' then
+		return dropItem(source, data)
+	end
 
-			local toInventory = (data.toType == 'player' and playerInventory) or Inventory(playerInventory.open)
-			local fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
+	local playerInventory = Inventory(source)
 
-			if not fromInventory then
-				Wait(0)
-				fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
+	if not playerInventory then return end
 
-				if not fromInventory then
-					return warn('Unknown error occured during swapItems\n', json.encode(data, {indent = true}))
-				end
+	local toInventory = (data.toType == 'player' and playerInventory) or Inventory(playerInventory.open)
+	local fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
+
+	if not fromInventory then
+		Wait(0)
+		fromInventory = (data.fromType == 'player' and playerInventory) or Inventory(playerInventory.open)
+
+		if not fromInventory then
+			return warn('Unknown error occured during swapItems\n', json.encode(data, {indent = true}))
+		end
+	end
+
+	if not toInventory then return end
+
+	local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
+	local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
+
+	-- while activeSlots[fromRef] or activeSlots[toRef] do
+	-- 	Wait(0)
+	-- end
+
+	if activeSlots[fromRef] or activeSlots[toRef] then return false end
+
+	activeSlots[fromRef] = true
+	activeSlots[toRef] = true
+
+	local _ <close> = defer(function()
+		activeSlots[fromRef] = nil
+		activeSlots[toRef] = nil
+	end)
+
+	local sameInventory = fromInventory.id == toInventory.id
+	local fromOtherPlayer = fromInventory.player and fromInventory ~= playerInventory
+	local toOtherPlayer = toInventory.player and toInventory ~= playerInventory
+
+	local toData = toInventory.items[data.toSlot]
+
+	if not sameInventory and (fromInventory.type == 'policeevidence' or (toInventory.type == 'policeevidence' and toData)) then
+		local group, rank = server.hasGroup(playerInventory, shared.police)
+
+		if not group or server.evidencegrade > rank then
+			return false, 'evidence_cannot_take'
+		end
+	end
+
+	if toInventory and fromInventory and (fromInventory.id ~= toInventory.id or data.fromSlot ~= data.toSlot) then
+		local fromData = fromInventory.items[data.fromSlot]
+
+		if fromData and (not fromData.metadata.container or fromData.metadata.container and toInventory.type ~= 'container') then
+			if data.count > fromData.count then data.count = fromData.count end
+
+			local container, containerItem = (not sameInventory and playerInventory.containerSlot) and (fromInventory.type == 'container' and fromInventory or toInventory)
+
+			if container then
+				containerItem = playerInventory.items[playerInventory.containerSlot]
 			end
 
-			if not toInventory then return end
+			local hookPayload = {
+				source = source,
+				fromInventory = fromInventory.id,
+				fromSlot = fromData,
+				fromType = fromInventory.type,
+				toInventory = toInventory.id,
+				toSlot = toData or data.toSlot,
+				toType = toInventory.type,
+				count = data.count,
+			}
 
-			local fromRef = ('%s:%s'):format(fromInventory.id, data.fromSlot)
-			local toRef = ('%s:%s'):format(toInventory.id, data.toSlot)
+			if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
+				-- Swap items
+				local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight) or 0
+				local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight) or 0
+				hookPayload.action = 'swap'
 
-			-- while activeSlots[fromRef] or activeSlots[toRef] do
-			-- 	Wait(0)
-			-- end
+				if not sameInventory then
+					if (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
+						if not TriggerEventHooks('swapItems', hookPayload) then return end
 
-			if activeSlots[fromRef] or activeSlots[toRef] then return false end
+						fromInventory.weight = fromWeight
+						toInventory.weight = toWeight
 
-			activeSlots[fromRef] = true
-			activeSlots[toRef] = true
+						if containerItem then
+							local toContainer = toInventory.type == 'container'
+							local whitelist = Items.containers[containerItem.name]?.whitelist
+							local blacklist = Items.containers[containerItem.name]?.blacklist
+							local checkItem = toContainer and fromData.name or toData.name
 
-			local _ <close> = defer(function()
-				activeSlots[fromRef] = nil
-				activeSlots[toRef] = nil
-			end)
-
-			local sameInventory = fromInventory.id == toInventory.id
-			local fromOtherPlayer = fromInventory.player and fromInventory ~= playerInventory
-			local toOtherPlayer = toInventory.player and toInventory ~= playerInventory
-
-			local toData = toInventory.items[data.toSlot]
-
-			if not sameInventory and (fromInventory.type == 'policeevidence' or (toInventory.type == 'policeevidence' and toData)) then
-				local group, rank = server.hasGroup(playerInventory, shared.police)
-
-				if not group or server.evidencegrade > rank then
-					return false, 'evidence_cannot_take'
-				end
-			end
-
-			if toInventory and fromInventory and (fromInventory.id ~= toInventory.id or data.fromSlot ~= data.toSlot) then
-				local fromData = fromInventory.items[data.fromSlot]
-
-				if fromData and (not fromData.metadata.container or fromData.metadata.container and toInventory.type ~= 'container') then
-					if data.count > fromData.count then data.count = fromData.count end
-
-					local container, containerItem = (not sameInventory and playerInventory.containerSlot) and (fromInventory.type == 'container' and fromInventory or toInventory)
-
-					if container then
-						containerItem = playerInventory.items[playerInventory.containerSlot]
-					end
-
-					local hookPayload = {
-						source = source,
-						fromInventory = fromInventory.id,
-						fromSlot = fromData,
-						fromType = fromInventory.type,
-						toInventory = toInventory.id,
-						toSlot = toData or data.toSlot,
-						toType = toInventory.type,
-						count = data.count,
-					}
-
-					if toData and ((toData.name ~= fromData.name) or not toData.stack or (not table.matches(toData.metadata, fromData.metadata))) then
-						-- Swap items
-						local toWeight = not sameInventory and (toInventory.weight - toData.weight + fromData.weight) or 0
-						local fromWeight = not sameInventory and (fromInventory.weight + toData.weight - fromData.weight) or 0
-						hookPayload.action = 'swap'
-
-						if not sameInventory then
-							if (toWeight <= toInventory.maxWeight and fromWeight <= fromInventory.maxWeight) then
-								if not TriggerEventHooks('swapItems', hookPayload) then return end
-
-								fromInventory.weight = fromWeight
-								toInventory.weight = toWeight
-
-								if containerItem then
-									local toContainer = toInventory.type == 'container'
-									local whitelist = Items.containers[containerItem.name]?.whitelist
-									local blacklist = Items.containers[containerItem.name]?.blacklist
-									local checkItem = toContainer and fromData.name or toData.name
-
-									if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then
-										return
-									end
-
-									Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight, playerInventory)
-								end
-
-								toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot) --[[@as table]]
-
-								if server.loglevel > 0 then
-									lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s" for %sx %s'):format(fromData.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id, toData.count, toData.name))
-								end
-							else return false, 'cannot_carry' end
-						else
-							if not TriggerEventHooks('swapItems', hookPayload) then return end
-
-							toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
-						end
-
-					elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
-						-- Stack items
-						toData.count += data.count
-						fromData.count -= data.count
-						local toSlotWeight = Inventory.SlotWeight(Items(toData.name), toData)
-						local totalWeight = toInventory.weight - toData.weight + toSlotWeight
-
-						if fromInventory.type == 'container' or sameInventory or totalWeight <= toInventory.maxWeight then
-							hookPayload.action = 'stack'
-
-							if not TriggerEventHooks('swapItems', hookPayload) then
-								toData.count -= data.count
-								fromData.count += data.count
+							if (whitelist and not whitelist[checkItem]) or (blacklist and blacklist[checkItem]) then
 								return
 							end
 
-							local fromSlotWeight = Inventory.SlotWeight(Items(fromData.name), fromData)
-							toData.weight = toSlotWeight
+							Inventory.ContainerWeight(containerItem, toContainer and toWeight or fromWeight, playerInventory)
+						end
 
-							if not sameInventory then
-								fromInventory.weight = fromInventory.weight - fromData.weight + fromSlotWeight
-								toInventory.weight = totalWeight
+						toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot) --[[@as table]]
 
-								if container then
-									Inventory.ContainerWeight(containerItem, toInventory.type == 'container' and toInventory.weight or fromInventory.weight, playerInventory)
-								end
+						if server.loglevel > 0 then
+							lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s" for %sx %s'):format(fromData.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id, toData.count, toData.name))
+						end
+					else return false, 'cannot_carry' end
+				else
+					if not TriggerEventHooks('swapItems', hookPayload) then return end
 
-								if server.loglevel > 0 then
-									lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s"'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id))
+					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
+				end
+
+			elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
+				-- Stack items
+				toData.count += data.count
+				fromData.count -= data.count
+				local toSlotWeight = Inventory.SlotWeight(Items(toData.name), toData)
+				local totalWeight = toInventory.weight - toData.weight + toSlotWeight
+
+				if fromInventory.type == 'container' or sameInventory or totalWeight <= toInventory.maxWeight then
+					hookPayload.action = 'stack'
+
+					if not TriggerEventHooks('swapItems', hookPayload) then
+						toData.count -= data.count
+						fromData.count += data.count
+						return
+					end
+
+					local fromSlotWeight = Inventory.SlotWeight(Items(fromData.name), fromData)
+					toData.weight = toSlotWeight
+
+					if not sameInventory then
+						fromInventory.weight = fromInventory.weight - fromData.weight + fromSlotWeight
+						toInventory.weight = totalWeight
+
+						if container then
+							Inventory.ContainerWeight(containerItem, toInventory.type == 'container' and toInventory.weight or fromInventory.weight, playerInventory)
+						end
+
+						if server.loglevel > 0 then
+							lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s"'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id))
+						end
+					end
+
+					fromData.weight = fromSlotWeight
+				else
+					toData.count -= data.count
+					fromData.count += data.count
+					return false, 'cannot_carry'
+				end
+			elseif data.count <= fromData.count then
+				-- Move item to an empty slot
+				toData = table.clone(fromData)
+				toData.count = data.count
+				toData.slot = data.toSlot
+				toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
+
+				if fromInventory.type == 'container' or sameInventory or (toInventory.weight + toData.weight <= toInventory.maxWeight) then
+					hookPayload.action = 'move'
+
+					if not TriggerEventHooks('swapItems', hookPayload) then return end
+
+					if not sameInventory then
+						local toContainer = toInventory.type == 'container'
+
+						if container then
+							if toContainer and containerItem then
+								local whitelist = Items.containers[containerItem.name]?.whitelist
+								local blacklist = Items.containers[containerItem.name]?.blacklist
+
+								if (whitelist and not whitelist[fromData.name]) or (blacklist and blacklist[fromData.name]) then
+									return
 								end
 							end
-
-							fromData.weight = fromSlotWeight
-						else
-							toData.count -= data.count
-							fromData.count += data.count
-							return false, 'cannot_carry'
 						end
-					elseif data.count <= fromData.count then
-						-- Move item to an empty slot
-						toData = table.clone(fromData)
-						toData.count = data.count
-						toData.slot = data.toSlot
-						toData.weight = Inventory.SlotWeight(Items(toData.name), toData)
 
-						if fromInventory.type == 'container' or sameInventory or (toInventory.weight + toData.weight <= toInventory.maxWeight) then
-							hookPayload.action = 'move'
+						fromInventory.weight -= toData.weight
+						toInventory.weight += toData.weight
 
-							if not TriggerEventHooks('swapItems', hookPayload) then return end
+						if container then
+							Inventory.ContainerWeight(containerItem, toContainer and toInventory.weight or fromInventory.weight, playerInventory)
+						end
 
-							if not sameInventory then
-								local toContainer = toInventory.type == 'container'
-
-								if container then
-									if toContainer and containerItem then
-										local whitelist = Items.containers[containerItem.name]?.whitelist
-										local blacklist = Items.containers[containerItem.name]?.blacklist
-
-										if (whitelist and not whitelist[fromData.name]) or (blacklist and blacklist[fromData.name]) then
-											return
-										end
-									end
-								end
-
-								fromInventory.weight -= toData.weight
-								toInventory.weight += toData.weight
-
-								if container then
-									Inventory.ContainerWeight(containerItem, toContainer and toInventory.weight or fromInventory.weight, playerInventory)
-								end
-
-								if server.loglevel > 0 then
-									lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s"'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id))
-								end
-							end
-
-							fromData.count -= data.count
-							fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
-
-							if fromData.count > 0 then
-								toData.metadata = table.clone(toData.metadata)
-							end
-						else return false, 'cannot_carry_other' end
-					end
-
-					if fromData and fromData.count < 1 then fromData = nil end
-
-					---@type updateSlot[]
-					local items = {}
-
-					if fromInventory.player and not fromOtherPlayer then
-						items[#items + 1] = {
-							item = fromData or { slot = data.fromSlot },
-							inventory = fromInventory.id
-						}
-
-						if toInventory.type == 'container' and containerItem then
-							items[#items + 1] = {
-								item = containerItem,
-								inventory = playerInventory.id
-							}
+						if server.loglevel > 0 then
+							lib.logger(playerInventory.owner, 'swapSlots', ('%sx %s transferred from "%s" to "%s"'):format(data.count, fromData.name, fromInventory.owner and fromInventory.label or fromInventory.id, toInventory.owner and toInventory.label or toInventory.id))
 						end
 					end
 
-					if toInventory.player and not toOtherPlayer then
-						items[#items + 1] = {
-							item = toData or { slot = data.toSlot },
-							inventory = toInventory.id
-						}
+					fromData.count -= data.count
+					fromData.weight = Inventory.SlotWeight(Items(fromData.name), fromData)
 
-						if fromInventory.type == 'container' and containerItem then
-							items[#items + 1] = {
-								item = containerItem,
-								inventory = playerInventory.id
-							}
-						end
+					if fromData.count > 0 then
+						toData.metadata = table.clone(toData.metadata)
 					end
+				else return false, 'cannot_carry_other' end
+			end
 
-					fromInventory.items[data.fromSlot] = fromData
-					toInventory.items[data.toSlot] = toData
+			if fromData and fromData.count < 1 then fromData = nil end
 
-					if fromInventory.changed ~= nil then fromInventory.changed = true end
-					if toInventory.changed ~= nil then toInventory.changed = true end
+			---@type updateSlot[]
+			local items = {}
 
-					if sameInventory then
-						fromInventory:syncSlotsWithClients({
-							{
-								item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
-								inventory = fromInventory.id
-							},
-							{
-								item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
-								inventory = fromInventory.id
-							}
-						}, { left = fromInventory.weight })
-					else
-						toInventory:syncSlotsWithClients({
-							{
-								item = toInventory.items[data.toSlot] or { slot = data.toSlot },
-								inventory = toInventory.id
-							}
-						}, { left = toInventory.weight })
+			if fromInventory.player and not fromOtherPlayer then
+				items[#items + 1] = {
+					item = fromData or { slot = data.fromSlot },
+					inventory = fromInventory.id
+				}
 
-						fromInventory:syncSlotsWithClients({
-							{
-								item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
-								inventory = fromInventory.id
-							}
-						}, { left = fromInventory.weight })
-					end
-
-					local resp
-
-					if next(items) then
-						resp = { weight = playerInventory.weight, items = items }
-
-						if server.syncInventory then
-							if fromInventory.player then
-								server.syncInventory(fromInventory)
-							end
-
-							if toInventory.player and not sameInventory then
-								server.syncInventory(toInventory)
-							end
-						end
-					end
-
-					local weaponSlot
-
-					if toInventory.weapon == data.toSlot then
-						if not sameInventory then
-							toInventory.weapon = nil
-							TriggerClientEvent('ox_inventory:disarm', toInventory.id)
-						else
-							weaponSlot = data.fromSlot
-							toInventory.weapon = weaponSlot
-						end
-					end
-
-					if fromInventory.weapon == data.fromSlot then
-						if not sameInventory then
-							fromInventory.weapon = nil
-							TriggerClientEvent('ox_inventory:disarm', fromInventory.id)
-						elseif not weaponSlot then
-							weaponSlot = data.toSlot
-							fromInventory.weapon = weaponSlot
-						end
-					end
-
-					return containerItem and containerItem.weight or true, resp, weaponSlot
+				if toInventory.type == 'container' and containerItem then
+					items[#items + 1] = {
+						item = containerItem,
+						inventory = playerInventory.id
+					}
 				end
 			end
+
+			if toInventory.player and not toOtherPlayer then
+				items[#items + 1] = {
+					item = toData or { slot = data.toSlot },
+					inventory = toInventory.id
+				}
+
+				if fromInventory.type == 'container' and containerItem then
+					items[#items + 1] = {
+						item = containerItem,
+						inventory = playerInventory.id
+					}
+				end
+			end
+
+			fromInventory.items[data.fromSlot] = fromData
+			toInventory.items[data.toSlot] = toData
+
+			if fromInventory.changed ~= nil then fromInventory.changed = true end
+			if toInventory.changed ~= nil then toInventory.changed = true end
+
+			if sameInventory then
+				fromInventory:syncSlotsWithClients({
+					{
+						item = fromInventory.items[data.toSlot] or { slot = data.toSlot },
+						inventory = fromInventory.id
+					},
+					{
+						item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
+						inventory = fromInventory.id
+					}
+				}, { left = fromInventory.weight })
+			else
+				toInventory:syncSlotsWithClients({
+					{
+						item = toInventory.items[data.toSlot] or { slot = data.toSlot },
+						inventory = toInventory.id
+					}
+				}, { left = toInventory.weight })
+
+				fromInventory:syncSlotsWithClients({
+					{
+						item = fromInventory.items[data.fromSlot] or { slot = data.fromSlot },
+						inventory = fromInventory.id
+					}
+				}, { left = fromInventory.weight })
+			end
+
+			local resp
+
+			if next(items) then
+				resp = { weight = playerInventory.weight, items = items }
+
+				if server.syncInventory then
+					if fromInventory.player then
+						server.syncInventory(fromInventory)
+					end
+
+					if toInventory.player and not sameInventory then
+						server.syncInventory(toInventory)
+					end
+				end
+			end
+
+			local weaponSlot
+
+			if toInventory.weapon == data.toSlot then
+				if not sameInventory then
+					toInventory.weapon = nil
+					TriggerClientEvent('ox_inventory:disarm', toInventory.id)
+				else
+					weaponSlot = data.fromSlot
+					toInventory.weapon = weaponSlot
+				end
+			end
+
+			if fromInventory.weapon == data.fromSlot then
+				if not sameInventory then
+					fromInventory.weapon = nil
+					TriggerClientEvent('ox_inventory:disarm', fromInventory.id)
+				elseif not weaponSlot then
+					weaponSlot = data.toSlot
+					fromInventory.weapon = weaponSlot
+				end
+			end
+
+			return containerItem and containerItem.weight or true, resp, weaponSlot
 		end
 	end
 end)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2070,7 +2070,7 @@ RegisterServerEvent('ox_inventory:giveItem', function(slot, target, count)
 
 		local item = Items(data.name)
 
-		if not toInventory.open and data and data.count >= count and Inventory.CanCarryItem(toInventory, item, count, data.metadata) and TriggerEventHooks('swapItems', {
+		if data.count >= count and Inventory.CanCarryItem(toInventory, item, count, data.metadata) and TriggerEventHooks('swapItems', {
 			source = fromInventory.id,
 			fromInventory = fromInventory.id,
 			fromType = fromInventory.type,

--- a/modules/items/shared.lua
+++ b/modules/items/shared.lua
@@ -13,6 +13,17 @@
 ---@field buttons? { label: string, action: fun(slot: number) }[] Add interactions when right-clicking an item.
 ---@field [string] any
 
+---@class SlotWithItem
+---@field name string
+---@field label string
+---@field weight number
+---@field slot number
+---@field count number
+---@field metadata { [string]: any }
+---@field description? string
+---@field stack? boolean
+---@field close? boolean
+
 ---@class OxClientProps
 ---@field status? { [string]: number }
 ---@field anim? string | { dict?: string, clip: string, flag?: number, blendIn?: number, blendOut?: number, duration?: number, playbackRate?: number, lockX?: boolean, lockY?: boolean, lockZ?: boolean, scenario?: string, playEnter?: boolean }

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -147,7 +147,8 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 		end
 
 		---@diagnostic disable-next-line: assign-type-mismatch
-		left.open = shop.id
+		Inventory.Open(left, left)
+		left.currentShop = shop.id
 	end
 
 	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }, shop
@@ -196,11 +197,11 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 
 		local playerInv = Inventory(source)
 
-		if not playerInv then return end
+		if not playerInv or not playerInv.currentShop then return end
 
-		local shopType, shopId = playerInv.open:match('^(.-) (%d-)$')
+		local shopType, shopId = playerInv.currentShop:match('^(.-) (%d-)$')
 
-		if not shopType then shopType = playerInv.open end
+		if not shopType then shopType = playerInv.currentShop end
 
 		if shopId then shopId = tonumber(shopId) end
 
@@ -216,9 +217,11 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 					data.count = fromData.count
 				end
 			end
+
 			if fromData.license and server.hasLicense and not server.hasLicense(playerInv, fromData.license) then
 				return false, false, { type = 'error', description = locale('item_unlicensed') }
 			end
+
 			if fromData.grade then
 				local _, rank = server.hasGroup(playerInv, shop.groups)
 				if not isRequiredGrade(fromData.grade, rank) then

--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -147,7 +147,7 @@ lib.callback.register('ox_inventory:openShop', function(source, data)
 		end
 
 		---@diagnostic disable-next-line: assign-type-mismatch
-		Inventory.Open(left, left)
+		left:openInventory(left)
 		left.currentShop = shop.id
 	end
 

--- a/modules/weapon/client.lua
+++ b/modules/weapon/client.lua
@@ -19,9 +19,7 @@ function Weapon.Equip(item, data)
 	local playerPed = cache.ped
 	local coords = GetEntityCoords(playerPed, true)
 
-	RequestWeaponAsset(data.hash, 31, 0)
-
-	while not HasWeaponAssetLoaded(data.hash) do Wait(0) end
+	lib.requestWeaponAsset(data.hash)
 
 	if client.weaponanims then
 		if cache.vehicle and vehicleIsCycle(cache.vehicle) then

--- a/server.lua
+++ b/server.lua
@@ -74,7 +74,7 @@ lib.callback.register('ox_inventory:openInventory', function(source, inv, data)
 	local left = Inventory(source) --[[@as OxInventory]]
 	local right
 
-	Inventory.CloseAll(left)
+	Inventory.CloseAll(left, (inv == 'drop' or inv == 'container' or not inv) and source)
 
 	if data then
 		if inv == 'stash' then

--- a/server.lua
+++ b/server.lua
@@ -138,11 +138,11 @@ lib.callback.register('ox_inventory:openInventory', function(source, inv, data)
 			end
 
 			if right.coords == nil or #(right.coords - GetEntityCoords(GetPlayerPed(source))) < 10 then
-				Inventory.Open(left, right)
+				left:openInventory(right)
 			else return end
 		else return end
 	else
-		Inventory.Open(left, left)
+		left:openInventory(left)
 	end
 
 	return {
@@ -309,7 +309,7 @@ lib.callback.register('ox_inventory:useItem', function(source, itemName, slot, m
 							if newItem then
 								newItem.metadata.durability = durability
 
-								TriggerClientEvent('ox_inventory:updateSlots', inventory.id, {
+								inventory:syncSlotsWithPlayer({
 									{
 										item = newItem,
 										inventory = inventory.type
@@ -333,7 +333,7 @@ lib.callback.register('ox_inventory:useItem', function(source, itemName, slot, m
 				else
 					inventory.changed = true
 
-					TriggerClientEvent('ox_inventory:updateSlots', inventory.id, {
+					inventory:syncSlotsWithPlayer({
 						{
 							item = inventory.items[data.slot],
 							inventory = inventory.type

--- a/server.lua
+++ b/server.lua
@@ -72,20 +72,9 @@ lib.callback.register('ox_inventory:openInventory', function(source, inv, data)
 	if Inventory.Lock then return false end
 
 	local left = Inventory(source) --[[@as OxInventory]]
-	---@type OxInventory|false|nil
-	local right = left.open and left.open ~= source and Inventory(left.open) or nil
+	local right
 
-	if right then
-		if right.open ~= source then return end
-
-		if right.player then
-			TriggerClientEvent('ox_inventory:closeInventory', right.id, true)
-		end
-
-		right:set('open', false)
-		left:set('open', false)
-		right = nil
-	end
+	Inventory.CloseAll(left)
 
 	if data then
 		if inv == 'stash' then
@@ -145,12 +134,11 @@ lib.callback.register('ox_inventory:openInventory', function(source, inv, data)
 			if right.player then right.coords = GetEntityCoords(GetPlayerPed(right.id)) end
 
 			if right.coords == nil or #(right.coords - GetEntityCoords(GetPlayerPed(source))) < 10 then
-				right.open = source
-				left.open = right.id
+				Inventory.Open(left, right)
 			else return end
 		else return end
 	else
-		left.open = source
+		Inventory.Open(left, left)
 	end
 
 	return {

--- a/server.lua
+++ b/server.lua
@@ -119,7 +119,7 @@ lib.callback.register('ox_inventory:openInventory', function(source, inv, data)
 		else right = Inventory(data) end
 
 		if right then
-			if right.open or (right.groups and not server.hasGroup(left, right.groups)) then return end
+			if right.groups and not server.hasGroup(left, right.groups) then return end
 
 			local hookPayload = {
 				source = source,
@@ -131,7 +131,11 @@ lib.callback.register('ox_inventory:openInventory', function(source, inv, data)
 
 			if not TriggerEventHooks('openInventory', hookPayload) then return end
 
-			if right.player then right.coords = GetEntityCoords(GetPlayerPed(right.id)) end
+			if right.player then
+				if right.open then return end
+
+				right.coords = GetEntityCoords(right.player.ped)
+			end
 
 			if right.coords == nil or #(right.coords - GetEntityCoords(GetPlayerPed(source))) < 10 then
 				Inventory.Open(left, right)

--- a/server.lua
+++ b/server.lua
@@ -199,7 +199,7 @@ end)
 ---@param source number
 ---@param itemName string
 ---@param slot number?
----@param metadata table?
+---@param metadata { [string]: any }?
 ---@return table | boolean | nil
 lib.callback.register('ox_inventory:useItem', function(source, itemName, slot, metadata)
 	local inventory = Inventory(source) --[[@as OxInventory]]

--- a/web/src/dnd/onDrop.ts
+++ b/web/src/dnd/onDrop.ts
@@ -4,6 +4,7 @@ import { store } from '../store';
 import { DragSource, DropTarget, InventoryType, SlotWithItem } from '../typings';
 import { moveSlots, stackSlots, swapSlots } from '../store/inventory';
 import { Items } from '../store/items';
+import { isEnvBrowser } from '../utils/misc';
 
 export const onDrop = (source: DragSource, target?: DropTarget) => {
   const { inventory: state } = store.getState();
@@ -59,6 +60,9 @@ export const onDrop = (source: DragSource, target?: DropTarget) => {
       toSlot: targetSlot.slot,
     })
   );
+
+  // Update slots if working in UI, otherwise rely on server callback
+  if (!isEnvBrowser()) return;
 
   isSlotWithItem(targetSlot, true)
     ? sourceData.stack && canStack(sourceSlot, targetSlot)


### PR DESCRIPTION
Allows for multiple players to access the same inventory, rather than the old behaviour of preventing additional players from opening an inventory.

inv.open always refer to the active inventory id (same as player id, if not in an inventory).
inv.openedBy is a set of player ids currently using the referenced inventory.

This changes behaviour of notifications somewhat to better reflect changes made to inventory state, but they may be somewhat spammy.

Currently only tested player-owned inventory when accessed by a single player, and standard stashes/vehicle stashes sync with two players. This cannot be merged until people have properly tested it and provided bug reports / feedback. There's almost definitely bugs causing desync at best, or item duplication at worst.

https://user-images.githubusercontent.com/65407488/230926091-c0033732-d293-48c9-9d62-6f6ae0a8a488.mp4

