### PR TITLE
feat(client): nested custom context buttons

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1154,7 +1154,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 
 		if buttons then
 			for i = 1, #v.buttons do
-				buttons[i] = v.buttons[i].label
+				buttons[i] = {label = v.buttons[i].label, group = v.buttons[i].group}
 			end
 		end
 

--- a/data/items.lua
+++ b/data/items.lua
@@ -26,6 +26,27 @@ return {
 				action = function(slot)
 					print('You squeezed the burger :(')
 				end
+			},
+			{
+				label = 'What do you call a vegan burger?',
+				group = 'Hamburger Puns',
+				action = function(slot)
+					print('A misteak.')
+				end
+			},
+			{
+				label = 'What do frogs like to eat with their hamburgers?',
+				group = 'Hamburger Puns',
+				action = function(slot)
+					print('French flies.')
+				end
+			},
+			{
+				label = 'Why were the burger and fries running?',
+				group = 'Hamburger Puns',
+				action = function(slot)
+					print('Because they\'re fast food.')
+				end
 			}
 		},
 		consume = 0.3

--- a/modules/items/shared.lua
+++ b/modules/items/shared.lua
@@ -10,7 +10,7 @@
 ---@field stack? boolean Set to false to prevent the item from stacking.
 ---@field close? boolean Set to false to keep the inventory open on item use.
 ---@field allowArmed? boolean Set to true to allow an item to be used while a weapon is equipped.
----@field buttons? { label: string, action: fun(slot: number) }[] Add interactions when right-clicking an item.
+---@field buttons? { label: string, group: string, action: fun(slot: number) }[] Add interactions when right-clicking an item.
 ---@field [string] any
 
 ---@class OxClientProps

--- a/web/src/components/inventory/InventoryContext.tsx
+++ b/web/src/components/inventory/InventoryContext.tsx
@@ -20,6 +20,23 @@ interface DataProps {
   id?: number;
 }
 
+interface Button {
+  label: string;
+  index: number;
+  group?: string;
+}
+
+interface Group {
+  groupName: string | null;
+  buttons: ButtonWithIndex[];
+}
+
+interface ButtonWithIndex extends Button {
+  index: number;
+}
+
+interface GroupedButtons extends Array<Group> {}
+
 const InventoryContext: React.FC = () => {
   const contextMenu = useAppSelector((state) => state.inventory.contextMenu);
   const item = contextMenu.item;
@@ -54,6 +71,28 @@ const InventoryContext: React.FC = () => {
         break;
     }
   };
+
+  const groupButtons = (buttons: any): GroupedButtons => {
+    return buttons.reduce((groups: Group[], button: Button, index: number) => {
+      if (button.group) {
+        const groupIndex = groups.findIndex((group) => group.groupName === button.group);
+        if (groupIndex !== -1) {
+          groups[groupIndex].buttons.push({ ...button, index });
+        } else {
+          groups.push({
+            groupName: button.group,
+            buttons: [{ ...button, index }],
+          });
+        }
+      } else {
+        groups.push({
+          groupName: null,
+          buttons: [{ ...button, index }],
+        });
+      }
+      return groups;
+    }, []);
+  }
 
   return (
     <>
@@ -98,10 +137,24 @@ const InventoryContext: React.FC = () => {
           <>
             {item &&
               item.name &&
-              Items[item.name]?.buttons?.map((label: string, index: number) => (
-                <MenuItem key={index} onClick={() => handleClick({ action: 'custom', id: index })}>
-                  {label}
-                </MenuItem>
+              groupButtons(Items[item.name]?.buttons).map((group: Group, index: number) => (
+                <div key={index}>
+                  {group.groupName ? (
+                    <NestedMenuItem parentMenuOpen={!!contextMenu} label={group.groupName}>
+                      {group.buttons.map((button: Button) => (
+                        <MenuItem key={button.index} onClick={() => handleClick({ action: 'custom', id: button.index })}>
+                          {button.label}
+                        </MenuItem>
+                      ))}
+                    </NestedMenuItem>
+                  ) : (
+                    group.buttons.map((button: Button) => (
+                      <MenuItem key={button.index} onClick={() => handleClick({ action: 'custom', id: button.index })}>
+                        {button.label}
+                      </MenuItem>
+                    ))
+                  )}
+                </div>
               ))}
           </>
         )}


### PR DESCRIPTION
Custom nested buttons. If you like buttons.

Use case: if you have a lot of interactions on an item and you want it to be neatly organized.

![Schermafbeelding 2023-04-16 135519](https://user-images.githubusercontent.com/30348563/232309037-5de979c9-fcc9-4155-a48b-aab9e1db673d.png)
