### PR TITLE
feat(inventory/server): new EnsureContainerExist export

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -256,6 +256,15 @@ local function getInventory(inv, owner)
 	end
 end
 
+---@param container table
+exports("EnsureContainerExist", function(container)
+	if container?.metadata?.container then
+		if Inventories[inv] == nil then
+			Inventory.Create(container.metadata.container, container.label, "container", container.metadata.size[1], 0, container.metadata.size[2], false)
+		end
+	end
+end)
+
 exports('Inventory', getInventory)
 exports('GetInventory', getInventory)
 


### PR DESCRIPTION
i have noticed after a test that containers until the player opens them are not created and therefore consequently a script cannot access the items inside until the player interacts with them. 
this export ensures that the container is created and therefore all exports linked to the inventories work as they should. 
this pull request can also be taken as an example to implement inventory types in exports or any other feature linked to containers.

---

**EnsureContainerExist**
guarantees that a container exists, this export should be called before any getter or setter export involving a container.

```lua
exports.ox_inventory:EnsureContainerExist(containerItem)
```

- containerItem: `table`
    - the item that is a container (example: paperbox)
    
**Example**
```
local ox_inventory = exports.ox_inventory

local paperBox = ox_inventory:Search(source, "slots", "paperbox")
ox_inventory:EnsureContainerExist(paperBox)

local paperBoxInventory = ox_inventory:GetInventory(paperBox.metadata.container)
print(json.encode(paperBoxInventory, {indent = true}))
--[[
    {
        "id": "RFZ1672534861",
        "type": "container",
        "slots": 10,
        "weight": 0,
        "maxWeight": 1000,
        "owner": false,
        "items": [...],
        ...
    }
]]
```