### PR TITLE
Getting correct plate from inventory type when inventory needs to be created

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -136,7 +136,7 @@ local function loadInventoryData(data, player)
 	end
 
 	if data.type == 'trunk' or data.type == 'glovebox' then
-		local plate = data.id:sub(6)
+		local plate = data.id:sub(data.type:len() + 1)
 
 		if server.trimplate then
 			plate = string.strtrim(plate)

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -184,6 +184,10 @@ local function loadInventoryData(data, player)
 			local model, class = lib.callback.await('ox_inventory:getVehicleData', source, data.netid)
 			local storage = Vehicles[data.type].models[model] or Vehicles[data.type][class]
 
+			if not storage then
+				return shared.info('Failed to load vehicle inventory configuration (vehicle does not have specific inventory configuration data/vehicles.lua).')
+			end
+
 			if Ox then
 				local vehicle = Ox.GetVehicle(entity)
 


### PR DESCRIPTION
When inventory doesn't exist and it needs to be created inventory type being trunk or glovebox plate is only grab for type being "trunk". 

First commit should fix the problem where plate will be taken depending length of the type. 

Second commit adds check that configuration for that specific vehicle trunk of glovebox configuration exists in the data/vehicles.lua to prevent erroring out.

```lua
local inventoryId = 'glovebox'..plate
exports.ox_inventory:GetInventory(inventoryId)
exports.ox_inventory:AddItem(inventoryId, 'water', 20)
```

```
[ script:ox_inventory] plate:   box42FJH944
[ script:ox_inventory] [info] Failed to load vehicle inventory data (no entity exists with given plate).
```