### PR TITLE
crafting - Enable opening by export even outside zones or when the zone is not created at all.

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -175,7 +175,7 @@ function client.openInventory(inv, data)
 				return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
 			end
 
-			left = lib.callback.await('ox_inventory:openCraftingBench', 200, data.id, data.index)
+			left = lib.callback.await('ox_inventory:openCraftingBench', 200, data.id, data.index, data.unlockpos)
 
 			if left then
 				right = CraftingBenches[data.id]
@@ -188,8 +188,10 @@ function client.openInventory(inv, data)
 					coords = GetEntityCoords(cache.ped)
 					distance = 2
 				else
-					coords = shared.target == 'ox_target' and right.zones and right.zones[data.index].coords or right.points and right.points[data.index]
-					distance = coords and shared.target == 'ox_target' and right.zones[data.index].distance or 2
+					if not data.unlockpos then
+						coords = shared.target == 'ox_target' and right.zones and right.zones[data.index].coords or right.points and right.points[data.index]
+						distance = coords and shared.target == 'ox_target' and right.zones[data.index].distance or 2
+					end
 				end
 
 				right = {

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -58,30 +58,34 @@ local function getCraftingCoords(source, bench, index)
 	end
 end
 
-lib.callback.register('ox_inventory:openCraftingBench', function(source, id, index)
+lib.callback.register('ox_inventory:openCraftingBench', function(source, id, index, unlockpos)
 	local left, bench = Inventory(source), CraftingBenches[id]
 
+	unlockpos = unlockpos or false
 	if not left then return end
-
-	if bench then
-		local groups = bench.groups
-		local coords = getCraftingCoords(source, bench, index)
-
-		if not coords then return end
-
-		if groups and not server.hasGroup(left, groups) then return end
-		if #(GetEntityCoords(GetPlayerPed(source)) - coords) > 10 then return end
-
-		if left.open and left.open ~= source then
-			local inv = Inventory(left.open) --[[@as OxInventory]]
-
-			-- Why would the player inventory open with an invalid target? Can't repro but whatever.
-			if inv?.player then
-				inv:closeInventory()
-			end
-		end
-
+	if unlockpos then
 		left:openInventory(left)
+	else
+		if bench then
+			local groups = bench.groups
+			local coords = getCraftingCoords(source, bench, index)
+
+			if not coords then return end
+
+			if groups and not server.hasGroup(left, groups) then return end
+			if #(GetEntityCoords(GetPlayerPed(source)) - coords) > 10 then return end
+
+			if left.open and left.open ~= source then
+				local inv = Inventory(left.open) --[[@as OxInventory]]
+
+				-- Why would the player inventory open with an invalid target? Can't repro but whatever.
+				if inv?.player then
+					inv:closeInventory()
+				end
+			end
+
+			left:openInventory(left)
+		end
 	end
 
 	return { label = left.label, type = left.type, slots = left.slots, weight = left.weight, maxWeight = left.maxWeight }


### PR DESCRIPTION
I needed to open crafting based on a specific condition and because I use target I always had to be near the zone and it was limited.

I added an unlockpos function to allow opening the crafting menu in other ways.


Example:
In a script where I have split illegal groups based on specific conditions and I couldn't use groupu so I needed this minor modification.
