### PR TITLE
Feat(Hooks): Add fromType to typeFilter

### DIFF
--- a/modules/hooks/server.lua
+++ b/modules/hooks/server.lua
@@ -49,7 +49,7 @@ local function TriggerEventHooks(event, payload)
 				goto skipLoop
 			end
 
-			if hook.typeFilter and not typeFilter(hook.typeFilter, payload.inventoryType or payload.shopType) then
+			if hook.typeFilter and not typeFilter(hook.typeFilter, payload.inventoryType or payload.shopType or payload.fromType) then
 				goto skipLoop
 			end
 


### PR DESCRIPTION
Beforehand it was only possible to use typeFilter on openInventory and BuyItem.

Now its possible to use it everywhere but will only works for fromType and not toType which might be a good idea to add later? idk but for now this would work for most.

Test code for before and after incase anyone wants to test it 🤷 

```lua
exports.ox_inventory:registerHook('swapItems', function(payload)
    print(json.encode(payload, { indent = true }))
    return false
end, {
    print = true,
    itemFilter = {
        water = true,
    },

    typeFilter = {
        player = true,
    }
})
```