### PR TITLE
QB Comp - Missing weapons module

### DIFF
--- a/modules/bridge/qb/client.lua
+++ b/modules/bridge/qb/client.lua
@@ -1,6 +1,7 @@
 local onLogout, Weapon = ...
 local QBCore = exports['qb-core']:GetCoreObject()
 local Inventory = require 'modules.inventory.client'
+local Weapon = require 'modules.weapon.client'
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', onLogout)
 


### PR DESCRIPTION
Was thrown error when a QB User was being cuffed with or withount holding a weapon.
https://github.com/overextended/ox_inventory/blob/b7f80a7b12a34558137cd0746c4217cf52d2c1fd/modules/bridge/qb/client.lua#L33