### PR TITLE
feat(client): specify displayMetadata order

### DIFF
--- a/modules/items/client.lua
+++ b/modules/items/client.lua
@@ -2,18 +2,27 @@ if not lib then return end
 
 local Items = require 'modules.items.shared' --[[@as table<string, OxClientItem>]]
 
----@param metadata table|string
+--- use array of single key value pairs to dictate order
+---@param metadata string | table<string, string> | table<string, string>[]
 ---@param value? string
----@param order? string[] if present must include all values of metadata table. Determines order metadata will be displayed in.
-local function displayMetadata(metadata, value, order)
+local function displayMetadata(metadata, value)
 	local data = {}
-	if type(metadata) == 'string' and value then data = { metadata = metadata, value = value }
-	elseif order then
-		for i = 1, #order do
-			local key = order[i]
-			data[i] = {
-				metadata = key,
-				value = metadata[key]
+
+	if type(metadata) == 'string' and value then data = { [1] = { metadata = metadata, value = value } }
+	elseif metadata[1] then -- assume its an array
+		for i = 1, #metadata do
+			for k, v in pairs(metadata[i]) do
+				data[i] = {
+					metadata = k,
+					value = v,
+				}
+			end
+		end
+	else
+		for k, v in pairs(metadata) do
+			data[#data+1] = {
+				metadata = k,
+				value = v,
 			}
 		end
 	end

--- a/modules/items/client.lua
+++ b/modules/items/client.lua
@@ -2,9 +2,22 @@ if not lib then return end
 
 local Items = require 'modules.items.shared' --[[@as table<string, OxClientItem>]]
 
-local function displayMetadata(metadata, value)
-	local data = metadata
-	if type(metadata) == 'string' and value then data = { [metadata] = value } end
+---@param metadata table|string
+---@param value? string
+---@param order? string[] if present must include all values of metadata table. Determines order metadata will be displayed in.
+local function displayMetadata(metadata, value, order)
+	local data = {}
+	if type(metadata) == 'string' and value then data = { metadata = metadata, value = value }
+	elseif order then
+		for i = 1, #order do
+			local key = order[i]
+			data[i] = {
+				metadata = key,
+				value = metadata[key]
+			}
+		end
+	end
+
 	SendNUIMessage({
 		action = 'displayMetadata',
 		data = data

--- a/web/src/components/inventory/SlotTooltip.tsx
+++ b/web/src/components/inventory/SlotTooltip.tsx
@@ -81,11 +81,11 @@ const SlotTooltip: React.FC<{ item: SlotWithItem; inventory: Inventory }> = ({ i
                   {Locale.ui_tint}: {item.metadata.weapontint}
                 </p>
               )}
-              {Object.keys(additionalMetadata).map((data: string, index: number) => (
+              {additionalMetadata.map((data: {metadata: string, value: string}, index: number) => (
                 <Fragment key={`metadata-${index}`}>
-                  {item.metadata && item.metadata[data] && (
+                  {item.metadata && item.metadata[data.metadata] && (
                     <p>
-                      {additionalMetadata[data]}: {item.metadata[data]}
+                      {data.value}: {item.metadata[data.metadata]}
                     </p>
                   )}
                 </Fragment>

--- a/web/src/components/inventory/index.tsx
+++ b/web/src/components/inventory/index.tsx
@@ -31,7 +31,7 @@ const Inventory: React.FC = () => {
 
   useNuiEvent('refreshSlots', (data) => dispatch(refreshSlots(data)));
 
-  useNuiEvent('displayMetadata', (data: { [key: string]: any }) => {
+  useNuiEvent('displayMetadata', (data: Array<{metadata: string, value: string}>) => {
     dispatch(setAdditionalMetadata(data));
   });
 

--- a/web/src/store/inventory.ts
+++ b/web/src/store/inventory.ts
@@ -24,7 +24,7 @@ const initialState: State = {
     maxWeight: 0,
     items: [],
   },
-  additionalMetadata: {},
+  additionalMetadata: new Array(),
   contextMenu: { coords: null },
   itemAmount: 0,
   shiftPressed: false,
@@ -46,8 +46,8 @@ export const inventorySlice = createSlice({
     ) => {
       state.contextMenu = action.payload;
     },
-    setAdditionalMetadata: (state, action: PayloadAction<{ [key: string]: any }>) => {
-      state.additionalMetadata = { ...state.additionalMetadata, ...action.payload };
+    setAdditionalMetadata: (state, action: PayloadAction<Array<{metadata: string, value: string}>>) => {
+      state.additionalMetadata = [ ...state.additionalMetadata, ...action.payload ];
     },
     setItemAmount: (state, action: PayloadAction<number>) => {
       state.itemAmount = action.payload;

--- a/web/src/typings/state.ts
+++ b/web/src/typings/state.ts
@@ -7,7 +7,7 @@ export type State = {
   itemAmount: number;
   shiftPressed: boolean;
   isBusy: boolean;
-  additionalMetadata: { [key: string]: any };
+  additionalMetadata: Array<{metadata: string, value: string}>;
   contextMenu: { coords: { mouseX: number; mouseY: number } | null; item?: Slot };
   history?: {
     leftInventory: Inventory;


### PR DESCRIPTION
- added optional parameter to displayMetadata to specify an order of metadata entries to display. Made some UI code adjustments to change to an array to preserve order.