### PR TITLE
fix(modules/items): durability nil value

### DIFF
--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -416,7 +416,7 @@ end
 ---@param ostime? number
 ---@return boolean? removed
 function Items.UpdateDurability(inv, slot, item, value, ostime)
-    local durability = slot.metadata.durability
+    local durability = slot.metadata.durability or 100
 
     if not durability then return end
 


### PR DESCRIPTION
When setting an items' durability with SetDurability, would not set the durability when durability has not been defined yet within the metadata