### PR TITLE
fix(server): Save inventories on restart

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2255,6 +2255,15 @@ AddEventHandler('txAdmin:events:serverShuttingDown', function()
 	Inventory.SaveInventories(true)
 end)
 
+AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
+    if eventData.secondsRemaining == 60 then
+        CreateThread(function()
+            Wait(45000)
+			Inventory.SaveInventories(true)
+        end)
+    end
+end)
+
 AddEventHandler('onResourceStop', function(resource)
 	if resource == shared.resource then
 		Inventory.SaveInventories(true)


### PR DESCRIPTION
Previously just before scheduled server restarts you were able to take an item out of your stash into your inventory and then when re-joining the item would be in your inventory and stash duplicating. Changing this prevented it.