### PR TITLE
fix (server) forceOpenInventory export fixes

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -223,7 +223,7 @@ end)
 ---@param invType string
 ---@param data string|number|table
 exports('forceOpenInventory', function(playerId, invType, data)
-	local left, right = openInventory(playerId, invType, data)
+	local left, right = openInventory(playerId, invType, data, true)
 
 	if left and right then
 		TriggerClientEvent('ox_inventory:forceOpenInventory', playerId, left, right)


### PR DESCRIPTION
Forceopeninventory export was meant to disable the security checks but it was never passed to the openInventory function