### PR TITLE
Create drop on ground

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -998,8 +998,11 @@ local function onExitDrop(point)
 end
 
 local function createDrop(dropId, data)
+	local coords = data.coords
+	local _, groundZ = GetGroundZFor_3dCoord(coords.x, coords.y, coords.z)
+	
 	local point = lib.points.new({
-		coords = data.coords,
+		coords = vector3(data.coords.x, data.coords.y, groundZ + 0.10),
 		distance = 16,
 		invId = dropId,
 		instance = data.instance,


### PR DESCRIPTION
Previously, when the player dropped the item, the marker would float. With this commit, when the player drops the item, the marker is on the ground.
![image](https://github.com/overextended/ox_inventory/assets/92694779/aa19b38e-041b-4631-9707-4b8b1d7de538)
