### PR TITLE
fix(server/shops): correct coords value

### DIFF
--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -86,7 +86,7 @@ local function createShop(shopType, id)
 		items = table.clone(shop.inventory),
 		slots = #shop.inventory,
 		type = 'shop',
-		coords = shared.target and shop.targets?[id]?.loc or shopLocations[id],
+		coords = shared.target and shop.targets?[id]?.loc or shopLocations[id].coords,
 		distance = shared.target and shop.targets?[id]?.distance,
 	}
 


### PR DESCRIPTION
Shops with target structure from ox_lib zones had wrong coords value, causing non-breaking client error upon first opening.