### PR TITLE
Marginal durability stacking feature

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1692,8 +1692,32 @@ lib.callback.register('ox_inventory:swapItems', function(source, data)
 					toData, fromData = Inventory.SwapSlots(fromInventory, toInventory, data.fromSlot, data.toSlot)
 				end
 
-			elseif toData and toData.name == fromData.name and table.matches(toData.metadata, fromData.metadata) then
 				-- Stack items
+
+				-- Extract durability for comparison
+				local toDurability = toData.metadata.durability or 0
+				local fromDurability = fromData.metadata.durability or 0
+
+				-- Clone metadata for comparison without durability
+				local toMetadataClone = table.clone(toData.metadata)
+				local fromMetadataClone = table.clone(fromData.metadata)
+				toMetadataClone.durability = nil
+				fromMetadataClone.durability = nil
+
+				-- Calculate the percentage difference
+				local percentDiff = math.abs(toDurability - fromDurability) / ((toDurability + fromDurability) / 2) * 100
+				print("Percentage difference in durability:", percentDiff) -- print the check
+
+				if toData and toData.name == fromData.name and table.matches(toMetadataClone, fromMetadataClone) then
+					if percentDiff <= 20 then
+						-- Set the durability to the lower of the two values
+						local newDurability = math.min(toDurability, fromDurability)
+						toData.metadata.durability = newDurability
+						fromData.metadata.durability = newDurability
+					else
+					end
+				end
+
 				toData.count += data.count
 				fromData.count -= data.count
 				local toSlotWeight = Inventory.SlotWeight(Items(toData.name), toData)


### PR DESCRIPTION
https://imgur.com/CCMPWNe

Upon swapping in inventory and attempting to stack an item (stack logic):

- It first extracts the 'durability' values of the two items. If the durability does not exist, it defaults to 0.
- It then clones the metadata of the two items for comparison, excluding the 'durability' property.
- It calculates the percentage difference between the two durabilities.
- It then checks if the items' names are the same and the rest of their metadata match.
- If the above check passes, it further checks if the difference in durability is 20% or less.
- If it is, it concludes that their durabilities are close enough. It then sets the durability of both items to the lower of the two durabilities.
- If it's more than 20%, it informs that their durabilities are too different & that it will proceed to swap logic (not provided in this script).