### PR TITLE
fix(client/inventory): check if boneIndex table is defined

### DIFF
--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -34,7 +34,7 @@ function Inventory.CanAccessTrunk(entity)
     ---@type number | number[]
     local doorId = checkVehicle and 4 or 5
 
-    if not Vehicles.trunk.boneIndex[vehicleHash] and not GetIsDoorValid(entity, doorId --[[@as number]]) then
+    if not Vehicles.trunk.boneIndex?[vehicleHash] and not GetIsDoorValid(entity, doorId --[[@as number]]) then
         if vehicleClass ~= 11 and (doorId ~= 5 or GetEntityBoneIndexByName(entity, 'boot') ~= -1 or not GetIsDoorValid(entity, 2)) then
             return
         end


### PR DESCRIPTION
fixes an error in https://github.com/overextended/ox_inventory/commit/bf69a767d3db9b5250c68d5f5cf9ccb9c7467faf which caused when attempting to use ox_target on a vehicle as the boneIndex table from data/vehicles.lua was removed