### PR TITLE
custom icon in data/shop.lua

### DIFF
--- a/modules/shops/client.lua
+++ b/modules/shops/client.lua
@@ -10,6 +10,7 @@ for shopType, shopData in pairs(data('shops') --[[@as table<string, OxShop>]]) d
 		groups = shopData.groups or shopData.jobs,
 		blip = shopData.blip,
 		label = shopData.label,
+        icon = shopData.icon
 	}
 
 	if shared.target then


### PR DESCRIPTION
Im not sure if thats correct, but I stumbled upon that while editing my ox_inventory.
I think its needed, bc if not, even though shop.icon is specified in shops.lua it wont get it when creating the target.