### PR TITLE
update(all/locales): unify translate variable, add missing CS locale

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1199,7 +1199,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 	end
 
 	uiLocales['$'] = locales['$']
-	uiLocales.ammo_type = locales.ammo_type
+	uiLocales.ui_ammo_type = locales.ui_ammo_type
 
 	client.drops = currentDrops
 

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -17,6 +17,8 @@
   "ui_ctrl_shift_lmb": "Rychle přesunout polovinu předmětů do druhého inventáře",
   "ui_alt_lmb": "Rychle použít předmět",
   "ui_ctrl_c": "Když najedete na zbraň, zkopírujete její sériové číslo",
+  "ui_remove_ammo": "Odebrat náboje",
+  "ui_ammo_type": "Ráže",
   "$": "$",
   "male": "Muž",
   "female": "Žena",

--- a/locales/de.json
+++ b/locales/de.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "Benutze einen Gegenstand",
   "ui_ctrl_c": "Wenn du über eine Waffe gehst, kopierst du die Seriennummer",
   "ui_remove_ammo": "Entferne Munition",
-  "ammo_type": "Munitionstyp",
+  "ui_ammo_type": "Munitionstyp",
   "$": "$",
   "male": "Männlich",
   "female": "Weiblich",

--- a/locales/en.json
+++ b/locales/en.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "Fast use an item",
   "ui_ctrl_c": "When hovering over a weapon, copies it's serial number",
   "ui_remove_ammo": "Remove ammo",
-  "ammo_type": "Ammo type",
+  "ui_ammo_type": "Ammo type",
   "$": "$",
   "male": "Male",
   "female": "Female",

--- a/locales/es.json
+++ b/locales/es.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "Usar rápidamente un objeto",
   "ui_ctrl_c": "Cuando se posa sobre un arma, copia su número de serie",
   "ui_remove_ammo": "Eliminar munición",
-  "ammo_type": "Tipo de munición",
+  "ui_ammo_type": "Tipo de munición",
   "$": "$",
   "male": "Masculino",
   "female": "Femenino",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "Käytä itemi nopeasti inventorystä",
   "ui_ctrl_c": "Hiiren ollessa aseen päällä, kopioi aseen sarjanumeron leikepöydälle",
   "ui_remove_ammo": "Poista Ammukset",
-  "ammo_type": "Ammustyyppi",
+  "ui_ammo_type": "Ammustyyppi",
   "$": "€",
   "male": "Mies",
   "female": "Nainen",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "Utiliser un item rapidement",
   "ui_ctrl_c": "En passant la souris sur une arme, copie son numéro de série",
   "ui_remove_ammo": "Vider le chargeur",
-  "ammo_type": "Type de munition",
+  "ui_ammo_type": "Type de munition",
   "$": "$",
   "male": "Homme",
   "female": "Femme",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "Tárgy gyorshasználat",
   "ui_ctrl_c": "Kurzor alatt lévő fegyver sorozatszámának másolása",
   "ui_remove_ammo": "Lőszer eltávolítása",
-  "ammo_type": "Lőszer típusa",
+  "ui_ammo_type": "Lőszer típusa",
   "$": "$",
   "male": "Férfi",
   "female": "Nő",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -18,7 +18,7 @@
 "ui_alt_lmb": "Greituju būdu panaudoti daiktą",
 "ui_ctrl_c": "Kol pelytė virš ginklo, nukopijuoja jo serijos numerį",
 "ui_remove_ammo": "Išimti kulkas",
-"ammo_type": "Kulkų tipas",
+"ui_ammo_type": "Kulkų tipas",
 "$": "$",
 "male": "Vyras",
 "female": "Moteris",

--- a/locales/no.json
+++ b/locales/no.json
@@ -18,7 +18,7 @@
     "ui_alt_lmb": "Bruk et element raskt",
     "ui_ctrl_c": "Når du svever over et våpen, kopierer du serienummeret",
     "ui_remove_ammo": "Fjern ammunisjon",
-    "ammo_type": "Ammunisjonstype",
+    "ui_ammo_type": "Ammunisjonstype",
     "$": "$",
     "male": "Mann",
     "female": "Kvinne",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "Szybkie użycie przedmiotu",
   "ui_ctrl_c": "Po najechaniu na broń, kopiuje jej numer seryjny",
   "ui_remove_ammo": "Usuń amunicje",
-  "ammo_type": "Typ amunicji",
+  "ui_ammo_type": "Typ amunicji",
   "$": "$",
   "male": "Mężczyzna",
   "female": "Kobieta",

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -19,7 +19,7 @@
   "ui_alt_lmb": "Brzo iskoristi predmet",
   "ui_ctrl_c": "Dok prelazis misem preko oruzja, kopira njegov serijski broj",
   "ui_remove_ammo": "Izvadi municiju",
-  "ammo_type": "Tip municije",
+  "ui_ammo_type": "Tip municije",
   "$": "$",
   "male": "Musko",
   "female": "Zensko",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "Hızlı item kullan",
   "ui_ctrl_c": "Bir silahın üzerine imleci getirdiğinde seri numarasını kopyala",
   "ui_remove_ammo": "Mermiyi kaldır",
-  "ammo_type": "Mermi Tipi",
+  "ui_ammo_type": "Mermi Tipi",
   "$": "$",
   "male": "Erkek",
   "female": "Kadın",

--- a/locales/zh-cn.json
+++ b/locales/zh-cn.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "快速使用物品",
   "ui_ctrl_c": "当悬停在武器上时，复制其序列号",
   "ui_remove_ammo": "移除弹药",
-  "ammo_type": "弹药类型",
+  "ui_ammo_type": "弹药类型",
   "$": "$",
   "male": "男性",
   "female": "女性",

--- a/locales/zh-tw.json
+++ b/locales/zh-tw.json
@@ -18,7 +18,7 @@
   "ui_alt_lmb": "物品快捷使用",
   "ui_ctrl_c": "將鼠標懸停在武器上時，複製其序列號",
   "ui_remove_ammo": "移除彈藥",
-  "ammo_type": "彈藥類型",
+  "ui_ammo_type": "彈藥類型",
   "$": "$",
   "male": "男",
   "female": "女",

--- a/web/src/components/inventory/SlotTooltip.tsx
+++ b/web/src/components/inventory/SlotTooltip.tsx
@@ -63,7 +63,7 @@ const SlotTooltip: React.ForwardRefRenderFunction<
               )}
               {ammoName && (
                 <p>
-                  {Locale.ammo_type}: {ammoName}
+                  {Locale.ui_ammo_type}: {ammoName}
                 </p>
               )}
               {item.metadata?.serial && (


### PR DESCRIPTION
Was looking for missing locales on weapons and stumbled upon this. I haven't found any other use case other than mostly UI, so I unified the prefix and added some missing CS locales.