### PR TITLE
fix: nd license check

### DIFF
--- a/modules/bridge/nd/client.lua
+++ b/modules/bridge/nd/client.lua
@@ -1,6 +1,6 @@
-local NDCore = lib.load('@ND_Core.init')
+if not lib.checkDependency('ND_Core', '2.0.0', true) then return end
 
-if lib.checkDependency('ND_Core', '2.0.0', true) then return end
+lib.load('@ND_Core.init')
 
 RegisterNetEvent("ND:characterUnloaded", client.onLogout)
 

--- a/modules/bridge/nd/server.lua
+++ b/modules/bridge/nd/server.lua
@@ -1,10 +1,9 @@
-local NDCore = lib.load('@ND_Core.init')
-
-if lib.checkDependency('ND_Core', '2.0.0', true) then return end
-
-AddEventHandler("ND:characterUnloaded", server.playerDropped)
+if not lib.checkDependency('ND_Core', '2.0.0', true) then return end
 
 local Inventory = require 'modules.inventory.server'
+lib.load('@ND_Core.init')
+
+AddEventHandler("ND:characterUnloaded", server.playerDropped)
 
 local function reorderGroups(groups)
     groups = groups or {}

--- a/modules/bridge/nd/server.lua
+++ b/modules/bridge/nd/server.lua
@@ -71,10 +71,12 @@ end
 
 ---@diagnostic disable-next-line: duplicate-set-field
 function server.hasLicense(inv, license)
-    local character = NDCore.getPlayer(inv.id)
-    if not character or not character.data.licences then return end
+    local player = NDCore.getPlayer(inv.id)
+    if not player then return end
 
-    for _, characterLicense in pairs(character.data.licences) do
+    local licenses = player.getMetadata("licenses") or {}
+    for i=1, #licenses do
+        local characterLicense = licenses[i]
         if characterLicense.type == license and characterLicense.status == "valid" then
             return characterLicense.type
         end


### PR DESCRIPTION
nd v1 had `.data` as metadata in v2 it's `.metadata` and there's a function to get specific metadata