### PR TITLE
Feat(shops): Use metadata label over item label

### DIFF
--- a/modules/shops/server.lua
+++ b/modules/shops/server.lua
@@ -267,7 +267,7 @@ lib.callback.register('ox_inventory:buyItem', function(source, data)
 
 				if server.syncInventory then server.syncInventory(playerInv) end
 
-				local message = locale('purchased_for', count, fromItem.label, (currency == 'money' and locale('$') or math.groupdigits(price)), (currency == 'money' and math.groupdigits(price) or ' '..Items(currency).label))
+				local message = locale('purchased_for', count, metadata?.label or fromItem.label, (currency == 'money' and locale('$') or math.groupdigits(price)), (currency == 'money' and math.groupdigits(price) or ' '..Items(currency).label))
 
 				if server.loglevel > 0 then
 					if server.loglevel > 1 or fromData.price >= 500 then


### PR DESCRIPTION
Makes it so that the shop message prioritizes the metadata label over the actual item label.

That way there's no conflictions between what the player sees in inventory versus the notify