### PR TITLE
(bridge:qb) Fix character name not showing on inventory

### DIFF
--- a/modules/bridge/qb/server.lua
+++ b/modules/bridge/qb/server.lua
@@ -40,7 +40,7 @@ end
 local function setupPlayer(Player)
 	Player.PlayerData.inventory = Player.PlayerData.items
 	Player.PlayerData.identifier = Player.PlayerData.citizenid
-
+	Player.PlayerData.name = ('%s %s'):format(Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname)
 	server.setPlayerInventory(Player.PlayerData)
 
 	Inventory.SetItem(Player.PlayerData.source, 'money', Player.PlayerData.money.cash)


### PR DESCRIPTION
QBCore PlayerData name is the steam/fivem name and needs to be overwritten to the name inside charinfo before setPlayerInventory