### PR TITLE
feat: non-persistent inventory

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -73,6 +73,7 @@ if IsDuplicityVersion() then
 else
     PlayerData = {}
     client = {
+        db = GetConvar('inventory:db', 1) == 1,
         autoreload = GetConvarInt('inventory:autoreload', 0) == 1,
         screenblur = GetConvarInt('inventory:screenblur', 1) == 1,
         keys = json.decode(GetConvar('inventory:keys', '')) or { 'F2', 'K', 'TAB' },

--- a/modules/bridge/client.lua
+++ b/modules/bridge/client.lua
@@ -63,10 +63,12 @@ function client.onLogout()
 	Weapon.Disarm()
 end
 
-local success, result = pcall(lib.load, ('modules.bridge.%s.client'):format(shared.framework))
+if shared.framework ~= 'none' then
+    local success, result = pcall(lib.load, ('modules.bridge.%s.client'):format(shared.framework))
 
-if not success then
-    lib.print.error(result)
-    lib = nil
-    return
+    if not success then
+        lib.print.error(result)
+        lib = nil
+        return
+    end
 end

--- a/modules/bridge/server.lua
+++ b/modules/bridge/server.lua
@@ -48,12 +48,14 @@ function server.playerDropped(source)
 	end
 end
 
-local success, result = pcall(lib.load, ('modules.bridge.%s.server'):format(shared.framework))
+if shared.framework ~= 'none' then
+    local success, result = pcall(lib.load, ('modules.bridge.%s.server'):format(shared.framework))
 
-if not success then
-    lib.print.error(result)
-    lib = nil
-    return
+    if not success then
+        lib.print.error(result)
+        lib = nil
+        return
+    end
 end
 
 if server.convertInventory then exports('ConvertItems', server.convertInventory) end

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -496,7 +496,7 @@ local function hasActiveInventory(playerId, owner)
 			end
 
 			Inventory.CloseAll(inventory)
-			db.savePlayer(owner, json.encode(inventory:minimal()))
+			if server.db then db.savePlayer(owner, json.encode(inventory:minimal())) end
 			Inventory.Remove(inventory)
 			Wait(100)
 		end
@@ -536,7 +536,7 @@ RegisterCommand('clearActiveIdentifier', function(source, args)
     end
 
     Inventory.CloseAll(inventory)
-    db.savePlayer(inventory.owner, json.encode(inventory:minimal()))
+    if server.db then db.savePlayer(inventory.owner, json.encode(inventory:minimal())) end
     Inventory.Remove(inventory)
 end, true)
 
@@ -669,6 +669,7 @@ end
 exports('UpdateVehicle', Inventory.UpdateVehicle)
 
 function Inventory.Save(inv)
+    if not server.db then return end
 	inv = Inventory(inv) --[[@as OxInventory]]
 
 	if not inv or inv.datastore then return end
@@ -1925,7 +1926,7 @@ function Inventory.Confiscate(source)
 	local inv = Inventories[source]
 
 	if inv?.player then
-		db.saveStash(inv.owner, inv.owner, json.encode(minimal(inv)))
+		if server.db then db.saveStash(inv.owner, inv.owner, json.encode(minimal(inv))) end
 		table.wipe(inv.items)
 		inv.weight = 0
 		inv.changed = true
@@ -2317,10 +2318,12 @@ local function saveInventories(clearInventories)
 end
 
 lib.cron.new('*/5 * * * *', function()
+    if not server.db then return end
     saveInventories(true)
 end)
 
 function Inventory.SaveInventories(lock, clearInventories)
+    if not server.db then return end
 	Inventory.Lock = lock or nil
 
 	Inventory.CloseAll()

--- a/modules/mysql/server.lua
+++ b/modules/mysql/server.lua
@@ -1,4 +1,4 @@
-if not lib then return end
+if not lib or not server.db then return end
 
 local Query = {
     SELECT_STASH = 'SELECT data FROM ox_inventory WHERE owner = ? AND name = ?',

--- a/server.lua
+++ b/server.lua
@@ -22,37 +22,39 @@ require 'modules.shops.server'
 function server.setPlayerInventory(player, data)
 	while not shared.ready do Wait(0) end
 
-	if not data then
-		data = db.loadPlayer(player.identifier)
-	end
+    local inventory = {}
+    local totalWeight = 0
 
-	local inventory = {}
-	local totalWeight = 0
+    if server.db then
+        if not data then
+            data = db.loadPlayer(player.identifier)
+        end
 
-	if data and next(data) then
-		local ostime = os.time()
+        if data and next(data) then
+            local ostime = os.time()
 
-		for _, v in pairs(data) do
-			if type(v) == 'number' or not v.count or not v.slot then
-				if server.convertInventory then
-					inventory, totalWeight = server.convertInventory(player.source, data)
-					break
-				else
-					return error(('Inventory for player.%s (%s) contains invalid data. Ensure you have converted inventories to the correct format.'):format(player.source, GetPlayerName(player.source)))
-				end
-			else
-				local item = Items(v.name)
+            for _, v in pairs(data) do
+                if type(v) == 'number' or not v.count or not v.slot then
+                    if server.convertInventory then
+                        inventory, totalWeight = server.convertInventory(player.source, data)
+                        break
+                    else
+                        return error(('Inventory for player.%s (%s) contains invalid data. Ensure you have converted inventories to the correct format.'):format(player.source, GetPlayerName(player.source)))
+                    end
+                else
+                    local item = Items(v.name)
 
-				if item then
-					v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
-					local weight = Inventory.SlotWeight(item, v)
-					totalWeight = totalWeight + weight
+                    if item then
+                        v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
+                        local weight = Inventory.SlotWeight(item, v)
+                        totalWeight = totalWeight + weight
 
-					inventory[v.slot] = {name = item.name, label = item.label, weight = weight, slot = v.slot, count = v.count, description = item.description, metadata = v.metadata, stack = item.stack, close = item.close}
-				end
-			end
-		end
-	end
+                        inventory[v.slot] = {name = item.name, label = item.label, weight = weight, slot = v.slot, count = v.count, description = item.description, metadata = v.metadata, stack = item.stack, close = item.close}
+                    end
+                end
+            end
+        end
+    end
 
 	player.source = tonumber(player.source)
 	local inv = Inventory.Create(player.source, player.name, 'player', shared.playerslots, totalWeight, shared.playerweight, player.identifier, inventory)

--- a/server.lua
+++ b/server.lua
@@ -22,35 +22,36 @@ require 'modules.shops.server'
 function server.setPlayerInventory(player, data)
 	while not shared.ready do Wait(0) end
 
+    if not data then
+        data = server.db and db.loadPlayer(player.identifier) or {}
+    end
+
     local inventory = {}
     local totalWeight = 0
 
-    if server.db then
-        if not data then
-            data = db.loadPlayer(player.identifier)
-        end
+    if data and next(data) then
+        local ostime = os.time()
 
-        if data and next(data) then
-            local ostime = os.time()
-
-            for _, v in pairs(data) do
-                if type(v) == 'number' or not v.count or not v.slot then
-                    if server.convertInventory then
-                        inventory, totalWeight = server.convertInventory(player.source, data)
-                        break
-                    else
-                        return error(('Inventory for player.%s (%s) contains invalid data. Ensure you have converted inventories to the correct format.'):format(player.source, GetPlayerName(player.source)))
-                    end
+        for _, v in pairs(data) do
+            if type(v) == 'number' or not v.count or not v.slot then
+                if server.convertInventory then
+                    inventory, totalWeight = server.convertInventory(player.source, data)
+                    break
                 else
-                    local item = Items(v.name)
+                    return error(('Inventory for player.%s (%s) contains invalid data. Ensure you have converted inventories to the correct format.')
+                    :format(player.source, GetPlayerName(player.source)))
+                end
+            else
+                local item = Items(v.name)
 
-                    if item then
-                        v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
-                        local weight = Inventory.SlotWeight(item, v)
-                        totalWeight = totalWeight + weight
+                if item then
+                    v.metadata = Items.CheckMetadata(v.metadata or {}, item, v.name, ostime)
+                    local weight = Inventory.SlotWeight(item, v)
+                    totalWeight = totalWeight + weight
 
-                        inventory[v.slot] = {name = item.name, label = item.label, weight = weight, slot = v.slot, count = v.count, description = item.description, metadata = v.metadata, stack = item.stack, close = item.close}
-                    end
+                    inventory[v.slot] = { name = item.name, label = item.label, weight = weight, slot = v.slot, count = v
+                    .count, description = item.description, metadata = v.metadata, stack = item.stack, close = item
+                    .close }
                 end
             end
         end


### PR DESCRIPTION
I had a use case where I needed the inventory to be "session based" and not save anything to the database. (eg. pvp sessions with items, loot, etc...). I don't know if this makes any sense for you but it's been useful for me so I'm sharing.

I also added the option to set framework to 'none' in case a bridge is not needed.

This is how I'm initialising the inventory on my end:
```lua
RegisterNetEvent('someServerEventHandler', function()
    local Inventory = exports['ox_inventory']
    local license2 = GetPlayerIdentifierByType(source, 'license2'):gsub('license2:', '')
    local name = GetPlayerName(source)

    Inventory:setPlayerInventory({
        source = source,
        identifier = license2,
        name = name,
        --groups: {}
    });
end)

```