### PR TITLE
feat(modules/weapons): add convar to disable weapon item notifications

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -81,6 +81,7 @@ else
         giveplayerlist = GetConvarInt('inventory:giveplayerlist', 0) == 1,
         weaponanims = GetConvarInt('inventory:weaponanims', 1) == 1,
         itemnotify = GetConvarInt('inventory:itemnotify', 1) == 1,
+        weaponnotify = GetConvarInt('inventory:weaponnotify', 1) == 1,
         imagepath = GetConvar('inventory:imagepath', 'nui://ox_inventory/web/images'),
         dropprops = GetConvarInt('inventory:dropprops', 0) == 1,
         dropmodel = joaat(GetConvar('inventory:dropmodel', 'prop_med_bag_01b')),

--- a/modules/weapon/client.lua
+++ b/modules/weapon/client.lua
@@ -86,7 +86,10 @@ function Weapon.Equip(item, data, noWeaponAnim)
 	end
 
 	TriggerEvent('ox_inventory:currentWeapon', item)
-	Utils.ItemNotify({ item, 'ui_equipped' })
+
+	if client.weaponnotify then
+		Utils.ItemNotify({ item, 'ui_equipped' })
+	end
 
 	return item, sleep
 end
@@ -123,7 +126,10 @@ function Weapon.Disarm(currentWeapon, noAnim)
 
 		::skipAnim::
 
-		Utils.ItemNotify({ currentWeapon, 'ui_holstered' })
+		if client.weaponnotify then
+			Utils.ItemNotify({ currentWeapon, 'ui_holstered' })
+		end
+
 		TriggerEvent('ox_inventory:currentWeapon')
 	end
 


### PR DESCRIPTION
Added `inventory:weaponnotify` convar which sets whether to show item notifications when player equips or holsters a weapon.
Enabled by default.