### PR TITLE
feat(server): add netid to openInventory hook payload

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -164,6 +164,7 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 		}
 
 		if invType == 'container' then hookPayload.slot = left.containerSlot end
+		if data.netid then hookPayload.netid = data.netid end
 
 		if not TriggerEventHooks('openInventory', hookPayload) then return end
 

--- a/server.lua
+++ b/server.lua
@@ -164,7 +164,7 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 		}
 
 		if invType == 'container' then hookPayload.slot = left.containerSlot end
-		if data.netid then hookPayload.netid = data.netid end
+		if data.netid then hookPayload.netId = data.netid end
 
 		if not TriggerEventHooks('openInventory', hookPayload) then return end
 


### PR DESCRIPTION
Send entity net ID in `openInventory` hook payload. Useful for additional security checks when opening  trunks, for example.