### PR TITLE
fix(server): Remove notification in CanCarryItem

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1366,7 +1366,6 @@ function Inventory.CanCarryItem(inv, item, count, metadata)
 				local newWeight = inv.weight + (weight * count)
 
 				if newWeight > inv.maxWeight then
-					TriggerClientEvent('ox_lib:notify', inv.id, { type = 'error', description = locale('cannot_carry') })
 					return false
 				end
 


### PR DESCRIPTION
This removes the 'cannot_carry' notification in CanCarryItem. It doesn't seem the right place to put the notification. When I use the export to check if a player can carry an item, it sometimes gives 2 notifications because of my own (notification) logic. There might also be cases where you want no notification at all.