### PR TITLE
fix(server): Fix rounding number in 'Inventory.Set'

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -301,7 +301,9 @@ function Inventory.Set(inv, k, v)
 	inv = Inventory(inv) --[[@as OxInventory]]
 
 	if inv then
-		if type(v) == 'number' then math.floor(v + 0.5) end
+		if type(v) == 'number' then
+			v = math.floor(v + 0.5)
+		end
 
 		if k == 'open' and v == false then
 			if inv.type ~= 'player' then


### PR DESCRIPTION
The change speaks for itself. Currently the value is not rouned, because the value is not set. This fixes that.