### PR TITLE
fix(client): Don't turn ped in 'Inventory.CanAccessTrunk'

### DIFF
--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -49,10 +49,6 @@ function Inventory.CanAccessTrunk(entity)
     offset = GetOffsetFromEntityInWorldCoords(entity, offset.x, offset.y, offset.z)
 
     if #(GetEntityCoords(cache.ped) - offset) < 1.5 then
-        local coords = GetEntityCoords(entity)
-
-        TaskTurnPedToFaceCoord(cache.ped, coords.x, coords.y, coords.z, 0)
-
         return doorId
     end
 end


### PR DESCRIPTION
It doesn't really make sense to do 'TaskTurnPedToFaceCoord' in the trunk check. Because its called when actually opening the trunk anyway.
Also when you have the 'inventory:target' convar enabled, this function is used to determine if the target option should appear, but at the same time the 'TaskTurnPedToFaceCoord' native gets repeatedly called.