### PR TITLE
fix(web): Reset 'shiftPressed' in inventory setup

### DIFF
--- a/web/src/reducers/setupInventory.ts
+++ b/web/src/reducers/setupInventory.ts
@@ -51,5 +51,6 @@ export const setupInventoryReducer: CaseReducer<
       }),
     };
 
+  state.shiftPressed = false;
   state.isBusy = false;
 };


### PR DESCRIPTION
Sometimes the shift key gets stuck when for example someone alt-tabs while holding the shift key. This 'stuck' state might lead to confusion, because of the stack-split.
The fix resets the 'shiftPressed' when (re-)opening the inventory.

If there is a better solution, please let me know.