### PR TITLE
fix(client): check if vehicle is locked in 'Inventory.CanAccessTrunk'

### DIFF
--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -44,6 +44,10 @@ function Inventory.CanAccessTrunk(entity)
         end
     end
 
+    if GetVehicleDoorLockStatus(entity) > 1 then
+        return
+    end
+
     local min, max = GetModelDimensions(vehicleHash)
     local offset = (max - min) * (not checkVehicle and vec3(0.5, 0, 0.5) or vec3(0.5, 1, 0.5)) + min
     offset = GetOffsetFromEntityInWorldCoords(entity, offset.x, offset.y, offset.z)


### PR DESCRIPTION
Currently, when you open a trunk and the owner locks that vehicle, the inventory will stay open and you are able to move items. This PR will change it so the trunk closes when the vehicle gets locked.