### PR TITLE
Fix parachute removed after Disarming a weapon

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1352,7 +1352,7 @@ RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inven
 		end
 
 		if client.parachute and GetPedParachuteState(playerPed) ~= -1 then
-			Utils.DeleteEntity(client.parachute)
+			Utils.DeleteEntity(client.parachute[1])
 			client.parachute = false
 		end
 

--- a/modules/bridge/client.lua
+++ b/modules/bridge/client.lua
@@ -33,7 +33,7 @@ function client.onLogout()
 	if not PlayerData.loaded then return end
 
 	if client.parachute then
-		Utils.DeleteEntity(client.parachute)
+		Utils.DeleteEntity(client.parachute[1])
 		client.parachute = false
 	end
 

--- a/modules/items/client.lua
+++ b/modules/items/client.lua
@@ -120,7 +120,7 @@ Item('parachute', function(data, slot)
 				GiveWeaponToPed(cache.ped, chute, 0, true, false)
 				SetPedGadget(cache.ped, chute, true)
 				lib.requestModel(1269906701)
-				client.parachute = CreateParachuteBagObject(cache.ped, true, true)
+				client.parachute = {CreateParachuteBagObject(cache.ped, true, true), slot?.metadata?.type or -1}
 				if slot.metadata.type then
 					SetPlayerParachuteTintIndex(PlayerData.id, slot.metadata.type)
 				end

--- a/modules/weapon/client.lua
+++ b/modules/weapon/client.lua
@@ -137,7 +137,7 @@ function Weapon.Disarm(currentWeapon, noAnim)
 		local chute = `GADGET_PARACHUTE`
 		GiveWeaponToPed(cache.ped, chute, 0, true, false)
 		SetPedGadget(cache.ped, chute, true)
-		SetPlayerParachuteTintIndex(PlayerData.id, -1)
+		SetPlayerParachuteTintIndex(PlayerData.id, client.parachute?[2] or -1)
 	end
 end
 

--- a/modules/weapon/client.lua
+++ b/modules/weapon/client.lua
@@ -132,6 +132,13 @@ function Weapon.Disarm(currentWeapon, noAnim)
 
 	Utils.WeaponWheel()
 	RemoveAllPedWeapons(cache.ped, true)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+		SetPlayerParachuteTintIndex(PlayerData.id, -1)
+	end
 end
 
 function Weapon.ClearAll(currentWeapon)


### PR DESCRIPTION
#### Current Issue:
After using a parachute, the object is created on the players back and the gadget/weapon is given to the player.
However if the player equips another weapon and then unequips it he loses the parachute. It is implemented in `Weapon.ClearAll` but not `Weapon.Disarm`

#### Changes:
- Added a check if `client.parachute` is not false and then equips it again after unequipping a weapon
- Refactored the structure & functionning of `client.parachute` to the following:
  - Convert it from just containing the object handle but also the tint index in an array, allows the parachute to have the same tint after disarm is called