### PR TITLE
fix(bridge/qb): improved handcuff status syncing

### DIFF
--- a/modules/bridge/qb/client.lua
+++ b/modules/bridge/qb/client.lua
@@ -22,15 +22,15 @@ RegisterNetEvent('QBCore:Player:SetPlayerData', function(data)
 
 		OnPlayerData('groups', PlayerData.groups)
 	end
-end)
 
-RegisterNetEvent('police:client:GetCuffed', function()
-	PlayerData.cuffed = not PlayerData.cuffed
-	LocalPlayer.state:set('invBusy', PlayerData.cuffed, false)
-
-	if not PlayerData.cuffed then return end
-
-	Weapon.Disarm()
+    if data.metadata.ishandcuffed then
+        PlayerData.cuffed = true
+        LocalPlayer.state:set('invBusy', true, false)
+        Weapon.Disarm()
+    elseif PlayerData.cuffed then
+        PlayerData.cuffed = false
+        LocalPlayer.state:set('invBusy', false, false)
+    end
 end)
 
 ---@diagnostic disable-next-line: duplicate-set-field


### PR DESCRIPTION
The current bridge code toggles handcuff status when receiving a handcuff event from QB. However without the context on whether the player is currently handcuffed this leads to the inventory setting cuffed status when they are actually being uncuffed or vise versa. This can be seen when relogging while cuffed for example, as the inventory doesn't persist the cuffed status, but QB would.

This PR sets cuffed status based on the player's QB metadata (source of truth) fixing the above sync issue, and aligning it with the same way the bridge handles other aspects of player data.

I'm still concerned there may be a race condition, where when the player loads in while cuffed, the inventory won't have loaded before the initial metadata is set, but metadata is likely updated every few seconds due to hunger/thirst, so the cuff status should quickly sync regardless. Also, if this was an issue it would be an issue for group status as well.