### PR TITLE
 fix(keybind): txAdmin default hotkey support

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -757,6 +757,8 @@ local function registerCommands()
 				return client.closeInventory()
 			end
 
+			if IsNuiFocused() then return end -- txAdmin default hotkey support
+
 			if cache.vehicle then
 				return openGlovebox(cache.vehicle)
 			end


### PR DESCRIPTION
fixes the default txAdmin hotkey being tab with the inventory's, no matter the framework (ox_core same issue)