### PR TITLE
fix(client): Prevent weapon disarm if weapon is currently being used

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -513,6 +513,12 @@ local function useSlot(slot, noAnim)
 			if IsCinematicCamRendering() then SetCinematicModeActive(false) end
 
 			if currentWeapon then
+				local weaponAmmo = currentWeapon.metadata.ammo
+
+				if weaponAmmo then
+					TriggerServerEvent('ox_inventory:updateWeapon', 'ammo', weaponAmmo) -- Update the ammo, incase the weapon is still being used right now.
+				end
+
 				local weaponSlot = currentWeapon.slot
 				currentWeapon = Weapon.Disarm(currentWeapon)
 


### PR DESCRIPTION
Currently, you can unlimitedly use ammo by unequipping the weapon you are using while shooting with it.
This PR solves this bug by preventing weapons from being unequipped while they are actively being used (aka weapon timer exists, and is bigger than 0).

Here is a demonstration video: https://streamable.com/oeoqjz

This "fix" would still not cover a case where the weapon is actively used and a "disarm" is called from elsewhere, but I guess that's a very rare edge case which should be handled by the calling script.