### PR TITLE
Rotate CustomDrop Model

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1032,6 +1032,8 @@ local function onEnterDrop(point)
 
 		SetModelAsNoLongerNeeded(model)
 		PlaceObjectOnGroundProperly(entity)
+		SetEntityCoords(entity, point.coords.x + point.offset.x, point.coords.y + point.offset.y, point.coords.z + point.offset.z)
+		SetEntityRotation(entity, point.rot.x, point.rot.y, point.rot.z, 5, true)
 		FreezeEntityPosition(entity, true)
 		SetEntityCollision(entity, false, true)
 
@@ -1054,7 +1056,9 @@ local function createDrop(dropId, data)
 		distance = 16,
 		invId = dropId,
 		instance = data.instance,
-		model = data.model
+		model = data.model,
+		rot = data.rot,
+		offset = data.offset,
 	})
 
 	if point.model or client.dropprops then

--- a/client.lua
+++ b/client.lua
@@ -1057,8 +1057,8 @@ local function createDrop(dropId, data)
 		invId = dropId,
 		instance = data.instance,
 		model = data.model,
-		rot = data.rot,
-		offset = data.offset,
+		rot = data.rot or vec3(0, 0, 0),
+		offset = data.offset or vec3(0, 0, 0),
 	})
 
 	if point.model or client.dropprops then

--- a/client.lua
+++ b/client.lua
@@ -1032,10 +1032,16 @@ local function onEnterDrop(point)
 
 		SetModelAsNoLongerNeeded(model)
 		PlaceObjectOnGroundProperly(entity)
-		SetEntityCoords(entity, point.coords.x + point.offset.x, point.coords.y + point.offset.y, point.coords.z + point.offset.z)
-		SetEntityRotation(entity, point.rot.x, point.rot.y, point.rot.z, 5, true)
 		FreezeEntityPosition(entity, true)
 		SetEntityCollision(entity, false, true)
+
+		if point.rot ~= nil then 
+			SetEntityRotation(entity, point.rot.x, point.rot.y, point.rot.z, 5, true)
+		end 
+
+		if point.offset ~= nil then 
+			SetEntityCoords(entity, point.coords.x + point.offset.x, point.coords.y + point.offset.y, point.coords.z + point.offset.z)
+		end 
 
 		point.entity = entity
 	end
@@ -1057,8 +1063,8 @@ local function createDrop(dropId, data)
 		invId = dropId,
 		instance = data.instance,
 		model = data.model,
-		rot = data.rot or vec3(0, 0, 0),
-		offset = data.offset or vec3(0, 0, 0),
+		rot = data.rot,
+		offset = data.offset,
 	})
 
 	if point.model or client.dropprops then

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -1483,7 +1483,7 @@ local function generateInvId(prefix)
 	end
 end
 
-local function CustomDrop(prefix, items, coords, slots, maxWeight, instance, model)
+local function CustomDrop(prefix, items, coords, slots, maxWeight, instance, model, rot, offset)
 	local dropId = generateInvId()
 	local inventory = Inventory.Create(dropId, ('%s %s'):format(prefix, dropId:gsub('%D', '')), 'drop', slots or shared.dropslots, 0, maxWeight or shared.dropweight, false, {})
 
@@ -1495,6 +1495,8 @@ local function CustomDrop(prefix, items, coords, slots, maxWeight, instance, mod
 		coords = inventory.coords,
 		instance = instance,
 		model = model,
+		rot = rot,
+		offset = offset,
 	}
 
 	TriggerClientEvent('ox_inventory:createDrop', -1, dropId, Inventory.Drops[dropId])


### PR DESCRIPTION
The goal of this PR is aimed at adding the ability to rotate the entity spawned when using `CustomDrop()`. This was done by adding a rotation to the entity along with a coordinate offset. The rotation and coordinate offset must be done after `PlaceObjectOnGroundProperly()` as it seems to reset the entity's rotation after calling in testing calling the native after applying the offsets. 

Using the native `SetEntityRotation()` requires a rotationOrder. 5 was chosen as it is the standard XYZ but different rotational orders can be found [here](https://docs.fivem.net/natives/?_0xAFBD61CC738D9EB9) if a different one is prefered.

Handling the case if the user doesn't want to set a rotation and offset was also considered by giving a default vec3(0,0,0) in it's place which would make the entity spawned use it's default values. This was chosen to be done when the point is created instead of the time when the entity is created so the entity's offset and rotation can be stored in the points data if someone would ever need that information. 