### PR TITLE
Style:(web/src) durabilty value

### DIFF
--- a/web/src/components/inventory/SlotTooltip.tsx
+++ b/web/src/components/inventory/SlotTooltip.tsx
@@ -53,7 +53,7 @@ const SlotTooltip: React.ForwardRefRenderFunction<
             <>
               {item.durability !== undefined && (
                 <p>
-                  {Locale.ui_durability}: {Math.trunc(item.durability)}
+                  {Locale.ui_durability}: {Math.min(Math.trunc(item.durability), 100)}
                 </p>
               )}
               {item.metadata?.ammo !== undefined && (

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -91,6 +91,7 @@ input[type='number']::-webkit-outer-spin-button {
 
 .tooltip-description {
   padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .tooltip-markdown > p {


### PR DESCRIPTION
Prevents durability in item description for exceeding 100 (in the cases where durability is directly modified by setmetadata) will require a rebuild of ui

Also adds a padding under the description so that Description and Durability have a line break