### PR TITLE
fix(modules/inventory): stash coords

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -194,6 +194,10 @@ local function loadInventoryData(data, player)
 
 			if not inventory then
 				inventory = Inventory.Create(stash.name, stash.label or stash.name, 'stash', stash.slots, 0, stash.maxWeight, owner, nil, stash.groups)
+
+                if stash.coords then
+					inventory.coords = stash.coords
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Adding the stash coords to the inventory data because now you can open stash everywhere you want even if you provide coords in RegisterStash