### PR TITLE
fix(bridge/qbx): default NPC vehicle database id to nil

### DIFF
--- a/modules/bridge/qbx/server.lua
+++ b/modules/bridge/qbx/server.lua
@@ -101,5 +101,5 @@ end
 ---@return number | string
 ---@diagnostic disable-next-line: duplicate-set-field
 function server.getOwnedVehicleId(entityId)
-    return Entity(entityId).state.vehicleid or exports.qbx_vehicles:GetVehicleIdByPlate(GetVehicleNumberPlateText(entityId)) or GetVehicleNumberPlateText(entityId)
+    return Entity(entityId).state.vehicleid or exports.qbx_vehicles:GetVehicleIdByPlate(GetVehicleNumberPlateText(entityId))
 end


### PR DESCRIPTION
This fixes an issue where the plate prefix would resolve via a partial match to the database id in the SQL query. This resulted in random NPCs vehicles providing illegal inventory access to player owned vehicles based off a partial plate match to the id.