### PR TITLE
fix(monorepo): allow support for a global monorepo

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ox_inventory",
+  "name": "ox_inventory_nui",
   "version": "1.0.0",
   "homepage": "web/build",
   "private": true,


### PR DESCRIPTION
using a monorepo structure and tooling such as turborepo causes issues when running commands like `pnpm build` or `pnpm watch` fails due to duplicated package names.