### PR TITLE
Item amount bug after crafting

### DIFF
--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -213,7 +213,8 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 							end
 
 							invSlot.count -= 1
-                            invSlot.weight -= item.weight
+                            invSlot.weight = Inventory.SlotWeight(item, invSlot)
+
 							left:syncSlotsWithClients({
 								{
 									item = invSlot,

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -213,6 +213,16 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 							end
 
 							invSlot.count -= 1
+							left:syncSlotsWithClients({
+								{
+									item = invSlot,
+									inventory = left.id
+								},
+								{
+									item = invSlot,
+									inventory = left.id
+								}
+							}, true)
 						else
                             Items.UpdateDurability(left, invSlot, item, durability < 0 and 0 or durability)
 						end

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -217,10 +217,6 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 								{
 									item = invSlot,
 									inventory = left.id
-								},
-								{
-									item = invSlot,
-									inventory = left.id
 								}
 							}, true)
 						else

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -213,6 +213,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 							end
 
 							invSlot.count -= 1
+                            invSlot.weight -= item.weight
 							left:syncSlotsWithClients({
 								{
 									item = invSlot,


### PR DESCRIPTION
- Synchronization of slots, that despite being used in craft still have same amount in UI as before the craft (the amount is not being updated for the UI, unless the slot with item is dragged). 
For me, It didn't work when and not the whole item, but only a part of its durability was used and therefore a new item with new durability was added to another slot, but the amount of items in the initial one remained the same as before craft.