### PR TITLE
fix: Shop Generation Icons for target

### DIFF
--- a/modules/shops/client.lua
+++ b/modules/shops/client.lua
@@ -164,7 +164,7 @@ local function refreshShops()
 							zoneId = Utils.CreateBoxZone(target, {
                                 {
                                     name = shopid,
-                                    icon = 'fas fa-shopping-basket',
+                                    icon = shop.icon or 'fas fa-shopping-basket',
                                     label = label,
                                     groups = shop.groups,
                                     onSelect = function()

--- a/modules/shops/client.lua
+++ b/modules/shops/client.lua
@@ -149,7 +149,7 @@ local function refreshShops()
 							scenario = target.scenario,
 							label = label,
 							groups = shop.groups,
-							icon = shop.icon,
+							icon = shop.icon or 'fas fa-shopping-basket',
 							iconColor = target.iconColor,
 							onEnter = onEnterShop,
 							onExit = onExitShop,


### PR DESCRIPTION
Solved two issues:
- where the targeting of a ped didn't have a fallback option.
- where the targeting of a zone always had the shopping basket icon (even if a different one was set)