### PR TITLE
feat: Making giveItem more intuitive

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2412,12 +2412,19 @@ local function giveItem(playerId, slot, target, count)
 	local fromInventory = Inventories[playerId]
 	local toInventory = Inventories[target]
 
-	if count <= 0 then count = 1 end
+	if count < 0 then return end
+	
 
 	if toInventory?.player then
 		local data = fromInventory.items[slot]
 
 		if not data then return end
+
+		if count == 0 then
+			count = data.count 
+		elseif count > data.count then
+			count = data.count
+		end
 
         local targetState = Player(target).state
 

--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -2412,15 +2412,15 @@ local function giveItem(playerId, slot, target, count)
 	local fromInventory = Inventories[playerId]
 	local toInventory = Inventories[target]
 
-	if count < 0 then return end
-	
 
 	if toInventory?.player then
 		local data = fromInventory.items[slot]
 
 		if not data then return end
 
-		if count == 0 then
+		if count < 0 then 
+			return { 'cannot_give', count, data.label }
+		elseif count == 0 then
 			count = data.count 
 		elseif count > data.count then
 			count = data.count


### PR DESCRIPTION
Before when giving a stack of items to another player an error would be given if the exact amount wasn't specified in the count box.

A single item was given when "0" was put in the count box which didn't feel intuitive.

With this change, if 0 is given the entire stack will be given, if an amount greater than the stack is used in the count box then the entire stack will be given, if somehow a negative is given an error is generated.

This change gives a more natural user experience.