### PR TITLE
RegisterCraftingBench

### DIFF
--- a/modules/crafting/client.lua
+++ b/modules/crafting/client.lua
@@ -96,7 +96,6 @@ end
 
 RegisterNetEvent('ox_inventory:registerCraftingBench', function(id, data)
     createCraftingBench(id, data)
-	return true
 end)
 
 for id, data in pairs(lib.callback.await('ox_inventory:getCraftingBenches', false)) do createCraftingBench(id, data) end

--- a/modules/crafting/client.lua
+++ b/modules/crafting/client.lua
@@ -94,6 +94,11 @@ local function createCraftingBench(id, data)
 	end
 end
 
-for id, data in pairs(lib.load('data.crafting')) do createCraftingBench(id, data) end
+lib.callback.register('ox_inventory:registerCraftingBench', function(id, data)
+    createCraftingBench(id, data)
+	return true
+end)
+
+for id, data in pairs(lib.callback.await('ox_inventory:getCraftingBenches', false)) do createCraftingBench(id, data) end
 
 return CraftingBenches

--- a/modules/crafting/client.lua
+++ b/modules/crafting/client.lua
@@ -98,6 +98,6 @@ RegisterNetEvent('ox_inventory:registerCraftingBench', function(id, data)
     createCraftingBench(id, data)
 end)
 
-for id, data in pairs(lib.callback.await('ox_inventory:getCraftingBenches', false)) do createCraftingBench(id, data) end
+lib.callback('ox_inventory:getCraftingBenches', false, function(data) for id, data in pairs(data) do createCraftingBench(id, data) end end)
 
 return CraftingBenches

--- a/modules/crafting/client.lua
+++ b/modules/crafting/client.lua
@@ -94,7 +94,7 @@ local function createCraftingBench(id, data)
 	end
 end
 
-lib.callback.register('ox_inventory:registerCraftingBench', function(id, data)
+RegisterNetEvent('ox_inventory:registerCraftingBench', function(id, data)
     createCraftingBench(id, data)
 	return true
 end)

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -49,7 +49,7 @@ for id, data in pairs(lib.load('data.crafting')) do createCraftingBench(id, data
 ---@param data table
 exports('RegisterCraftingBench', function(id, data)
 	createCraftingBench(id, data)
-	lib.callback('ox_inventory:registerCraftingBench', -1, function() end, id, data)
+	TriggerClientEvent('ox_inventory:registerCraftingBench', -1, id, data)
 end)
 
 lib.callback.register('ox_inventory:getCraftingBenches', function(source)

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -45,6 +45,17 @@ end
 
 for id, data in pairs(lib.load('data.crafting')) do createCraftingBench(id, data) end
 
+---@param id number
+---@param data table
+exports('RegisterCraftingBench', function(id, data)
+	createCraftingBench(id, data)
+	lib.callback('ox_inventory:registerCraftingBench', -1, function() end, id, data)
+end)
+
+lib.callback.register('ox_inventory:getCraftingBenches', function(source)
+    return CraftingBenches
+end)
+
 ---falls back to player coords if zones and points are both nil
 ---@param source number
 ---@param bench table


### PR DESCRIPTION
Created the `RegisterCraftingBench` export server-side so that developers can create benches dynamically in the same was as stashes. I didn't concern myself with security for the client event as the main scripts code handles distance checks and checking if a bench exists.