### PR TITLE
fix(server/mysql): fix stashes saving string

### DIFF
--- a/modules/mysql/server.lua
+++ b/modules/mysql/server.lua
@@ -268,7 +268,7 @@ function db.saveInventories(players, trunks, gloveboxes, stashes, total)
                         end
                     end
 
-                    shared.info(saveStr:format('stashes', affectedRows, total[4], (os.nanotime() - start) / 1e6))
+                    shared.info(saveStr:format(affectedRows, total[4], 'stashes', (os.nanotime() - start) / 1e6))
                 end
             end)
         end


### PR DESCRIPTION
previous state would throw `bad argument #1 to 'format' (number expected, got string)` as it expect the first argument to be number and not string