### PR TITLE
fix(crafting) issue :  #1848 :Weight discrepancy during crafting

### DIFF
--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -117,7 +117,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 			-- Modified weight calculation
 			local newWeight = left.weight
 			local items = Inventory.Search(left, 'slots', tbl) or {}
-			
+			---@todo new iterator or something to accept a map
 			-- First subtract weight of ingredients that will be removed
 			for name, needs in pairs(recipe.ingredients) do
 				if needs > 0 then


### PR DESCRIPTION
1 > Properly account for weight changes from durability consumption
2 > Keep server and client weights synchronized
3 > Handle zero durability item removal correctly
4 > Fix the weight discrepancy after multiple crafts