### PR TITLE
fix(server): update entity and plate check logic

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -161,12 +161,7 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
                 if right and data.netid ~= right.netid then
                     local invEntity = NetworkGetEntityFromNetworkId(right.netid)
 
-					if DoesEntityExist(invEntity) and plate then
-						local invEntityPlate = GetVehicleNumberPlateText(invEntity)
-						if invEntityPlate and not invEntityPlate:match(plate) then
-							return
-						end
-					end
+					if DoesEntityExist(invEntity) and plate and not string.match(GetVehicleNumberPlateText(invEntity), plate) then return end
 
                     Inventory.Remove(right)
                     right = Inventory(data)

--- a/server.lua
+++ b/server.lua
@@ -161,7 +161,12 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
                 if right and data.netid ~= right.netid then
                     local invEntity = NetworkGetEntityFromNetworkId(right.netid)
 
-                    if DoesEntityExist(invEntity) or plate and not string.match(GetVehicleNumberPlateText(invEntity), plate) then return end
+					if DoesEntityExist(invEntity) and plate then
+						local invEntityPlate = GetVehicleNumberPlateText(invEntity)
+						if invEntityPlate and not invEntityPlate:match(plate) then
+							return
+						end
+					end
 
                     Inventory.Remove(right)
                     right = Inventory(data)


### PR DESCRIPTION
Fixes a script error caused by nil being passed to `string.match` when `DoesEntityExist(invEntity)` returns false.