### PR TITLE
Make easy crafting hook for ox inventory

### DIFF
--- a/data/crafting.lua
+++ b/data/crafting.lua
@@ -1,5 +1,6 @@
 return {
 	{
+        name = 'debug_crafting',
 		items = {
 			{
 				name = 'lockpick',

--- a/modules/crafting/server.lua
+++ b/modules/crafting/server.lua
@@ -113,7 +113,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 
 			local craftedItem = Items(recipe.name)
 			local craftCount = (type(recipe.count) == 'number' and recipe.count) or (table.type(recipe.count) == 'array' and math.random(recipe.count[1], recipe.count[2])) or 1
-			
+
 			-- Modified weight calculation
 			local newWeight = left.weight
 			local items = Inventory.Search(left, 'slots', tbl) or {}
@@ -127,7 +127,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 					end
 				end
 			end
-			
+
 			-- Add weight of crafted item
 			newWeight += (craftedItem.weight + (recipe.metadata?.weight or 0)) * craftCount
 
@@ -186,6 +186,7 @@ lib.callback.register('ox_inventory:craftItem', function(source, id, index, reci
 				source = source,
 				benchId = id,
 				benchIndex = index,
+                benchName = bench.name or nil,
 				recipe = recipe,
 				toInventory = left.id,
 				toSlot = toSlot,


### PR DESCRIPTION
I've been using this method for a very long time, it's time for me to share hehe
This will make you not have to worry if you create a new crafting in writing random inline code.
In the doc, we need benchId and/or benchIndex for specific bench what we want.
But we will make it easier and safer when making a hook by just giving it its name

This add new parameter for documentation in crafting hooks

> benchName : string (optional)

For usage, just like this
```lua
local hooks = exports.ox_inventory:registerHook('craftItem', function(payload)
    if payload.benchName == 'debug_crafting' then
        -- add your code for the hooks, maybe logs ?
    end
    return true
end)
```
Conclusion: This method only helps make it easier for you to create a hook using a pre-set name without having to look at or calculate the benchId that has been created in crafting.lua. Sorry for my bad english, hope it helps

Discord Forum Post : [Overextended Discord](https://discord.com/channels/813030955598086174/1325799824473194598/1325799824473194598)