### PR TITLE
Support for entity lockdown with dumpsters

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -19,6 +19,7 @@ shared = {
     playerweight = GetConvarInt('inventory:weight', 30000),
     target = GetConvarInt('inventory:target', 0) == 1,
     police = json.decode(GetConvar('inventory:police', '["police", "sheriff"]')),
+    entitylockdown = GetConvarInt('inventory:entitylockdown', 0) == 1
 }
 
 shared.dropslots = GetConvarInt('inventory:dropslots', shared.playerslots)

--- a/init.lua
+++ b/init.lua
@@ -19,7 +19,7 @@ shared = {
     playerweight = GetConvarInt('inventory:weight', 30000),
     target = GetConvarInt('inventory:target', 0) == 1,
     police = json.decode(GetConvar('inventory:police', '["police", "sheriff"]')),
-    entitylockdown = GetConvarInt('inventory:entitylockdown', 0) == 1
+    networkdumpsters = GetConvarInt('inventory:networkdumpsters', 0) == 1
 }
 
 shared.dropslots = GetConvarInt('inventory:dropslots', shared.playerslots)

--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -4,18 +4,24 @@ local Inventory = {}
 
 Inventory.Dumpsters = {218085040, 666561306, -58485588, -206690185, 1511880420, 682791951}
 
+-- Make sure dumpsters are frozen to ensure persistent position across clients
+SetInterval(function()
+	local objects = GetGamePool('CObject')
+
+	for i = 1, #objects do
+		local object = objects[i]
+		local model = GetEntityModel(object)
+
+		if lib.table.contains(Inventory.Dumpsters, model) and not IsEntityPositionFrozen(object) then
+			FreezeEntityPosition(object, true)
+		end
+	end
+end, 3000)
+
 function Inventory.OpenDumpster(entity)
-	local netId = NetworkGetEntityIsNetworked(entity) and NetworkGetNetworkIdFromEntity(entity)
+	local coords = GetEntityCoords(entity)
 
-	if not netId then
-		local coords = GetEntityCoords(entity)
-		entity = GetClosestObjectOfType(coords.x, coords.y, coords.z, 0.1, GetEntityModel(entity), true, true, true)
-		netId = entity ~= 0 and NetworkGetNetworkIdFromEntity(entity)
-	end
-
-	if netId then
-		client.openInventory('dumpster', 'dumpster'..netId)
-	end
+	client.openInventory('dumpster', coords)
 end
 
 local Utils = require 'modules.utils.client'

--- a/modules/inventory/client.lua
+++ b/modules/inventory/client.lua
@@ -4,7 +4,7 @@ local Inventory = {}
 
 Inventory.Dumpsters = {218085040, 666561306, -58485588, -206690185, 1511880420, 682791951}
 
-if shared.entitylockdown then
+if shared.networkdumpsters then
 	-- Make sure dumpsters are frozen to ensure persistent position across clients
 	SetInterval(function()
 		local objects = GetGamePool('CObject')
@@ -21,7 +21,7 @@ if shared.entitylockdown then
 end
 
 function Inventory.OpenDumpster(entity)
-	if shared.entitylockdown then
+	if shared.networkdumpsters then
 		local coords = GetEntityCoords(entity)
 		client.openInventory('dumpster', coords)
 		return

--- a/server.lua
+++ b/server.lua
@@ -197,13 +197,26 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 				right = Inventory(('evidence-%s'):format(data))
 			end
 		elseif invType == 'dumpster' then
-			local dumpsterId = getDumpsterFromCoords(data)
-			right = dumpsterId and Inventory(('dumpster-%s'):format(dumpsterId))
+			if shared.entitylockdown then
+				local dumpsterId = getDumpsterFromCoords(data)
+				right = dumpsterId and Inventory(('dumpster-%s'):format(dumpsterId))
 
-			if not right then
-				dumpsterId = #registeredDumpsters + 1
-				right = Inventory.Create(('dumpster-%s'):format(dumpsterId), locale('dumpster'), invType, 15, 0, 100000, false)
-				registeredDumpsters[dumpsterId] = data
+				if not right then
+					dumpsterId = #registeredDumpsters + 1
+					right = Inventory.Create(('dumpster-%s'):format(dumpsterId), locale('dumpster'), invType, 15, 0, 100000, false)
+					registeredDumpsters[dumpsterId] = data
+				end
+			else
+				---@cast data string
+				right = Inventory(data)
+
+				if not right then
+					local netid = tonumber(data:sub(9))
+	
+					if netid and NetworkGetEntityFromNetworkId(netid) > 0 then
+						right = Inventory.Create(data, locale('dumpster'), invType, 15, 0, 100000, false)
+					end
+				end
 			end
 		elseif invType == 'container' then
 			left.containerSlot = data --[[@as number]]

--- a/server.lua
+++ b/server.lua
@@ -197,7 +197,7 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 				right = Inventory(('evidence-%s'):format(data))
 			end
 		elseif invType == 'dumpster' then
-			if shared.entitylockdown then
+			if shared.networkdumpsters then
 				local dumpsterId = getDumpsterFromCoords(data)
 				right = dumpsterId and Inventory(('dumpster-%s'):format(dumpsterId))
 


### PR DESCRIPTION
This implementation has been tested extensively and worked flawlessly during all tests. The only limitation is that dumpsters need to be frozen when nearby to maintain a consistent position across clients. Given that dumpsters in the game tend to move like cardboard boxes, this could also be considered an improvement haha.

If anyone has suggestions to improve this further, feedback is welcome!