### PR TITLE
fix(convert.lua): compare number with string

### DIFF
--- a/setup/convert.lua
+++ b/setup/convert.lua
@@ -99,9 +99,10 @@ local function ConvertESX()
 
 		for k, v in pairs(accounts) do
 			if type(v) == 'table' then break end
-			if server.accounts[k] and Items(k) and v > 0 then
+            local amount = tonumber(v)
+			if server.accounts[k] and Items(k) and amount > 0 then
 				slot += 1
-				inventory[slot] = {slot=slot, name=k, count=v}
+				inventory[slot] = {slot=slot, name=k, count=amount}
 			end
 		end
 


### PR DESCRIPTION
Recently I tried to convert ESX inventory to OX and ended up with:
```lua
[ script:ox_inventory] SCRIPT ERROR: @ox_inventory/setup/convert.lua:102: attempt to compare number with string
[ script:ox_inventory] > fn (@ox_inventory/setup/convert.lua:102)
[ script:ox_inventory] > rawQuery (@oxmysql/dist/build.js:26045)
[ script:ox_inventory] > runMicrotasks (<anonymous>:0)
[ script:ox_inventory] > processTicksAndRejections (node:internal/process/task_queues:96)
```

This should fix this.