### PR TITLE
Added pre-filling item containers

### DIFF
--- a/modules/inventory/server.lua
+++ b/modules/inventory/server.lua
@@ -397,6 +397,17 @@ function Inventory.SetSlot(inv, item, count, metadata, slot)
 	inv.items[slot] = currentSlot
 	inv.changed = true
 
+	if metadata.container and metadata.items then
+		local container = Inventory.GetContainerFromSlot(inv, slot)
+		local itemsToAdd = metadata.items
+		if container and itemsToAdd then
+			for i = 1, #itemsToAdd do
+				local item = itemsToAdd[i]
+				Inventory.AddItem(container, item.name, item.count)
+			end
+		end
+	end
+	
 	return currentSlot
 end
 

--- a/modules/items/containers.lua
+++ b/modules/items/containers.lua
@@ -48,6 +48,7 @@ local function setContainerProperties(itemName, properties)
 		size = { properties.slots, properties.maxWeight },
 		blacklist = blacklist,
 		whitelist = whitelist,
+		items = properties.items or nil
 	}
 end
 
@@ -60,7 +61,10 @@ setContainerProperties('paperbag', {
 setContainerProperties('pizzabox', {
 	slots = 5,
 	maxWeight = 1000,
-	whitelist = { 'pizza' }
+	whitelist = { 'pizza' },
+	items = {
+		{ item = 'pizza', count = 1 }
+	}
 })
 
 return containers

--- a/modules/items/server.lua
+++ b/modules/items/server.lua
@@ -195,6 +195,7 @@ function Items.Metadata(inv, item, metadata, count)
 			count = 1
 			metadata.container = metadata.container or GenerateText(3)..os.time()
 			metadata.size = container.size
+			metadata.items = container.items or nil
 		elseif not next(metadata) then
 			if item.name == 'identification' then
 				count = 1


### PR DESCRIPTION
This pull request introduces functionality to prepopulate containers when they are created, allowing you to define preset containers with specific items.

This is useful for scenarios such as:

Lootable Crates – Ensure predefined loot spawns in chests or boxes.
Starter Kits – Automatically provide a set of items inside of a box.
Item Packages - Items that would come prepackaged in bulk like a pack of cigarettes that contains 10 cigarettes.
Mission Rewards – Quest-related items directly into an item container.

If a dev passes the items property table in when they define a new item container, it will add those items in the container when the item is received via the AddItem function.

An example was added to the pizzabox container, where it will add 1x Pizza.