### PR TITLE
fix(init.lua): drop weight

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -23,7 +23,7 @@ shared = {
 }
 
 shared.dropslots = GetConvarInt('inventory:dropslots', shared.playerslots)
-shared.dropweight = GetConvarInt('inventory:dropslotcount', shared.playerweight)
+shared.dropweight = GetConvarInt('inventory:dropweight', shared.playerweight)
 
 do
     if type(shared.police) == 'string' then


### PR DESCRIPTION
Invalid convar for dropweight was set.

# Maximum drop capacity, in grams
setr inventory:dropweight 30000

https://overextended.dev/ox_inventory#config